### PR TITLE
Enabling compilation on Linux

### DIFF
--- a/Sources/SFSymbols/Extensions/Button+Extension.swift
+++ b/Sources/SFSymbols/Extensions/Button+Extension.swift
@@ -5,6 +5,7 @@
 //  Created by Richard Witherspoon on 4/22/21.
 //
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 
@@ -54,3 +55,4 @@ extension Button where Label == SwiftUI.Label<Text, Image>{
         }
     }
 }
+#endif

--- a/Sources/SFSymbols/Extensions/Image+Extension.swift
+++ b/Sources/SFSymbols/Extensions/Image+Extension.swift
@@ -5,6 +5,7 @@
 //  Created by Richard Witherspoon on 4/22/21.
 //
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 extension Image{
@@ -12,3 +13,4 @@ extension Image{
         self.init(systemName: symbol.title)
     }
 }
+#endif

--- a/Sources/SFSymbols/Extensions/Label+Extension.swift
+++ b/Sources/SFSymbols/Extensions/Label+Extension.swift
@@ -5,6 +5,7 @@
 //  Created by Richard Witherspoon on 4/22/21.
 //
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 
@@ -26,3 +27,4 @@ extension Label where Title == Text, Icon == Image {
         self.init(.init(title), symbol: symbol, textColor: textColor)
     }
 }
+#endif


### PR DESCRIPTION
I'm building an app which uses SFSymbols for tag and folder icons, and I'm adding server-side validation to ensure that only valid SFSymbols are used. This pull request allows all the models to compile on Linux with minimal changes, just by adding #if canImport(SwiftUI) wrappers around all of the SwiftUI extensions your library provides.

Hope to get this working, and thank you for the hard work building out this library!