### PR TITLE
Added release on tag yml

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,27 @@
+name: Create Release on Tag
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release pushed tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+        run: |
+          gh release create "$tag" \
+              --repo="$GITHUB_REPOSITORY" \
+              --title="$tag" \
+              --generate-notes


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automatically create a release when a new tag is pushed to the repository.

Automation for release creation:

* [`.github/workflows/release-on-tag.yml`](diffhunk://#diff-906e630a07a825c223f35d1c346b423dc8278cf379479ad687528f1a6e943b7aR1-R27): Introduced a new workflow named "Create Release on Tag" that triggers on tag pushes, checks out the code, and uses the `gh` CLI to create a release with autogenerated notes.