### PR TITLE
SF Symbols 7.1 (116) Update

### DIFF
--- a/Sources/SFSymbols/Models/SFCategory.swift
+++ b/Sources/SFSymbols/Models/SFCategory.swift
@@ -56,7 +56,7 @@ public struct SFCategory: Identifiable, Codable, Equatable, Hashable, Sendable {
     public static let shapes = SFCategory(icon: "square.on.circle", title: "Shapes")
     public static let arrows = SFCategory(icon: "arrow.forward", title: "Arrows")
     public static let indices = SFCategory(icon: "a.circle", title: "Indices")
-    public static let math = SFCategory(icon: "x.squareroot", title: "Math")
+    public static let math = SFCategory(icon: "radicand.squareroot", title: "Math")
 
     public static var allCategories: [SFCategory] {
         return [

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables13.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables13.swift
@@ -18613,14 +18613,14 @@ public extension SFSymbol {
 
     /// x.squareroot
     /// - Since: iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0
-    /// - Layersets: monochrome, hierarchical
+    /// - Layersets: monochrome
     @available(*, deprecated, renamed: "radicandSquareroot", message: "Use 'radicandSquareroot' instead. This symbol has been renamed.")
     static let xSquareroot = SFSymbol(
         title: "x.squareroot",
-        categories: [.draw],
+        categories: nil,
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
-        layersets: [.monochrome, .hierarchical],
+        layersets: [.monochrome],
         deprecatedNewName: "radicand.squareroot"
     )
 

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables14.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables14.swift
@@ -6205,13 +6205,13 @@ public extension SFSymbol {
 
     /// keyboard.macwindow
     /// - Since: iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0
-    /// - Layersets: monochrome
+    /// - Layersets: monochrome, hierarchical, multicolor
     static let keyboardMacwindow = SFSymbol(
         title: "keyboard.macwindow",
         categories: [.multicolor],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
-        layersets: [.monochrome]
+        layersets: [.monochrome, .hierarchical, .multicolor]
     )
 
     /// keyboard.onehanded.left
@@ -10813,13 +10813,13 @@ public extension SFSymbol {
 
     /// text.and.command.macwindow
     /// - Since: iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0
-    /// - Layersets: monochrome
+    /// - Layersets: monochrome, hierarchical, multicolor
     static let textAndCommandMacwindow = SFSymbol(
         title: "text.and.command.macwindow",
         categories: [.multicolor],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
-        layersets: [.monochrome]
+        layersets: [.monochrome, .hierarchical, .multicolor]
     )
 
     /// text.below.photo

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables15.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables15.swift
@@ -8798,7 +8798,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let trashSlashCircle = SFSymbol(
         title: "trash.slash.circle",
-        categories: [.multicolor, .objectsAndTools, .variable],
+        categories: [.multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables17.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables17.swift
@@ -9153,7 +9153,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sliderHorizontal2Square = SFSymbol(
         title: "slider.horizontal.2.square",
-        categories: [.editing, .draw],
+        categories: [.editing],
         searchTerms: ["adjust", "edit"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables18.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables18.swift
@@ -8567,14 +8567,14 @@ public extension SFSymbol {
 
     /// head.profile.arrow.forward.and.vision.pro
     /// - Since: iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0
-    /// - Layersets: monochrome, hierarchical
+    /// - Layersets: monochrome
     @available(*, deprecated, renamed: "headProfileVisionProRemove", message: "Use 'headProfileVisionProRemove' instead. This symbol has been renamed.")
     static let headProfileArrowForwardAndVisionPro = SFSymbol(
         title: "head.profile.arrow.forward.and.vision.pro",
         categories: nil,
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
-        layersets: [.monochrome, .hierarchical],
+        layersets: [.monochrome],
         deprecatedNewName: "head.profile.vision.pro.remove"
     )
 
@@ -13909,7 +13909,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sliderHorizontal2RectangleAndArrowTrianglehead2ClockwiseRotate90 = SFSymbol(
         title: "slider.horizontal.2.rectangle.and.arrow.trianglehead.2.clockwise.rotate.90",
-        categories: [.draw],
+        categories: nil,
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables26.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables26.swift
@@ -426,14 +426,14 @@ public extension SFSymbol {
 
     /// ac.slash
     /// - Since: iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0
-    /// - Layersets: monochrome, hierarchical
+    /// - Layersets: monochrome
     @available(*, deprecated, renamed: "airConditionerSlash", message: "Use 'airConditionerSlash' instead. This symbol has been renamed.")
     static let acSlash = SFSymbol(
         title: "ac.slash",
-        categories: [.draw],
+        categories: nil,
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
-        layersets: [.monochrome, .hierarchical],
+        layersets: [.monochrome],
         deprecatedNewName: "air.conditioner.slash"
     )
 
@@ -3714,26 +3714,26 @@ public extension SFSymbol {
 
     /// macwindow.and.pointer.arrow
     /// - Since: iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0
-    /// - Layersets: monochrome, hierarchical
+    /// - Layersets: monochrome, hierarchical, multicolor
     /// - Localizations: Right-to-Left
     static let macwindowAndPointerArrow = SFSymbol(
         title: "macwindow.and.pointer.arrow",
         categories: [.multicolor],
         searchTerms: ["cursor"],
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
-        layersets: [.monochrome, .hierarchical],
+        layersets: [.monochrome, .hierarchical, .multicolor],
         localizations: [LocalizationInfo(code: .rtl, availability: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0))]
     )
 
     /// macwindow.stack
     /// - Since: iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0
-    /// - Layersets: monochrome
+    /// - Layersets: monochrome, multicolor
     static let macwindowStack = SFSymbol(
         title: "macwindow.stack",
         categories: [.multicolor, .whatsNew],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
-        layersets: [.monochrome]
+        layersets: [.monochrome, .multicolor]
     )
 
     /// minus.arrow.trianglehead.clockwise

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables26P1.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables26P1.swift
@@ -21,24 +21,24 @@ public extension SFSymbol {
 
     /// air.conditioner.slash
     /// - Since: iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1
-    /// - Layersets: monochrome
+    /// - Layersets: monochrome, hierarchical
     static let airConditionerSlash = SFSymbol(
         title: "air.conditioner.slash",
-        categories: [.automotive, .whatsNew],
+        categories: [.automotive, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1),
-        layersets: [.monochrome]
+        layersets: [.monochrome, .hierarchical]
     )
 
     /// arrowtriangle.backward.inset.filled.trailingthird.rectangle
     /// - Since: iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1
-    /// - Layersets: monochrome
+    /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowtriangleBackwardInsetFilledTrailingthirdRectangle = SFSymbol(
         title: "arrowtriangle.backward.inset.filled.trailingthird.rectangle",
-        categories: [.multicolor, .whatsNew],
+        categories: [.multicolor, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1),
-        layersets: [.monochrome]
+        layersets: [.monochrome, .hierarchical, .multicolor]
     )
 
     /// arrowtriangle.down.2
@@ -65,13 +65,13 @@ public extension SFSymbol {
 
     /// arrowtriangle.forward.inset.filled.trailingthird.rectangle
     /// - Since: iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1
-    /// - Layersets: monochrome
+    /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowtriangleForwardInsetFilledTrailingthirdRectangle = SFSymbol(
         title: "arrowtriangle.forward.inset.filled.trailingthird.rectangle",
-        categories: [.multicolor, .whatsNew],
+        categories: [.multicolor, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1),
-        layersets: [.monochrome]
+        layersets: [.monochrome, .hierarchical, .multicolor]
     )
 
     /// arrowtriangle.up.2
@@ -164,13 +164,13 @@ public extension SFSymbol {
 
     /// camera.viewfinder.badge.automatic
     /// - Since: iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1
-    /// - Layersets: monochrome
+    /// - Layersets: monochrome, hierarchical, multicolor
     static let cameraViewfinderBadgeAutomatic = SFSymbol(
         title: "camera.viewfinder.badge.automatic",
         categories: [.cameraAndPhotos, .multicolor, .objectsAndTools, .whatsNew],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1),
-        layersets: [.monochrome]
+        layersets: [.monochrome, .hierarchical, .multicolor]
     )
 
     /// digitalcrown
@@ -227,95 +227,95 @@ public extension SFSymbol {
 
     /// head.profile.vision.pro.remove
     /// - Since: iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1
-    /// - Layersets: monochrome
+    /// - Layersets: monochrome, hierarchical
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple Vision Pro.
     static let headProfileVisionProRemove = SFSymbol(
         title: "head.profile.vision.pro.remove",
         categories: [.devices],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1),
-        layersets: [.monochrome],
+        layersets: [.monochrome, .hierarchical],
         restriction: "This symbol may not be modified and may only be used to refer to Apple Vision Pro."
     )
 
     /// inset.filled.rectangle.and.person.filled.slash
     /// - Since: iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1
-    /// - Layersets: monochrome
+    /// - Layersets: monochrome, hierarchical
     /// - Localizations: Right-to-Left
     static let insetFilledRectangleAndPersonFilledSlash = SFSymbol(
         title: "inset.filled.rectangle.and.person.filled.slash",
         categories: [.human, .whatsNew],
-        searchTerms: nil,
+        searchTerms: ["people", "screen sharing"],
         releaseInfo: ReleaseInfo(iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1),
-        layersets: [.monochrome],
+        layersets: [.monochrome, .hierarchical],
         localizations: [LocalizationInfo(code: .rtl, availability: ReleaseInfo(iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1))]
     )
 
     /// radicand.squareroot
     /// - Since: iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1
-    /// - Layersets: monochrome
+    /// - Layersets: monochrome, hierarchical
     /// - Localizations: Arabic
     static let radicandSquareroot = SFSymbol(
         title: "radicand.squareroot",
-        categories: [.math],
+        categories: [.math, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1),
-        layersets: [.monochrome],
+        layersets: [.monochrome, .hierarchical],
         localizations: [LocalizationInfo(code: .ar, availability: ReleaseInfo(iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1))]
     )
 
     /// rectangle.badge.sparkles
     /// - Since: iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1
-    /// - Layersets: monochrome
+    /// - Layersets: monochrome, hierarchical
     static let rectangleBadgeSparkles = SFSymbol(
         title: "rectangle.badge.sparkles",
         categories: [.whatsNew],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1),
-        layersets: [.monochrome]
+        layersets: [.monochrome, .hierarchical]
     )
 
     /// rectangle.badge.sparkles.fill
     /// - Since: iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1
-    /// - Layersets: monochrome
+    /// - Layersets: monochrome, hierarchical
     static let rectangleBadgeSparklesFill = SFSymbol(
         title: "rectangle.badge.sparkles.fill",
         categories: [.whatsNew],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1),
-        layersets: [.monochrome]
+        layersets: [.monochrome, .hierarchical]
     )
 
     /// slider.horizontal.below.sun.min
     /// - Since: iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1
-    /// - Layersets: monochrome
+    /// - Layersets: monochrome, hierarchical
     static let sliderHorizontalBelowSunMin = SFSymbol(
         title: "slider.horizontal.below.sun.min",
         categories: [.editing, .whatsNew],
-        searchTerms: nil,
+        searchTerms: ["adjust", "edit"],
         releaseInfo: ReleaseInfo(iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1),
-        layersets: [.monochrome]
+        layersets: [.monochrome, .hierarchical]
     )
 
     /// star.rectangle
     /// - Since: iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1
-    /// - Layersets: monochrome
+    /// - Layersets: monochrome, hierarchical
     static let starRectangle = SFSymbol(
         title: "star.rectangle",
-        categories: [.whatsNew],
-        searchTerms: nil,
+        categories: [.whatsNew, .draw],
+        searchTerms: ["favorite"],
         releaseInfo: ReleaseInfo(iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1),
-        layersets: [.monochrome]
+        layersets: [.monochrome, .hierarchical]
     )
 
     /// star.rectangle.fill
     /// - Since: iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1
-    /// - Layersets: monochrome
+    /// - Layersets: monochrome, hierarchical, multicolor
     static let starRectangleFill = SFSymbol(
         title: "star.rectangle.fill",
         categories: [.multicolor, .whatsNew],
-        searchTerms: nil,
+        searchTerms: ["favorite"],
         releaseInfo: ReleaseInfo(iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1),
-        layersets: [.monochrome]
+        layersets: [.monochrome, .hierarchical, .multicolor]
     )
 }


### PR DESCRIPTION
- Ran the upgrade script against SF Symbols 7.1 (116) on 26.2 (25C56).
  - Updates to categories, search terms, and layer sets  