### PR TITLE
Exclude watchOS from UIKit-only SFSymbol initializers

### DIFF
--- a/Sources/SFSymbols/Extensions/UIAction+Init.swift
+++ b/Sources/SFSymbols/Extensions/UIAction+Init.swift
@@ -4,7 +4,7 @@
 //  Generated from UIKit.framework
 //
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 import UIKit
 
 @available(iOS 13.0, tvOS 14.0, *)

--- a/Sources/SFSymbols/Extensions/UICommand+Init.swift
+++ b/Sources/SFSymbols/Extensions/UICommand+Init.swift
@@ -4,7 +4,7 @@
 //  Generated from UIKit.framework
 //
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 import UIKit
 
 @available(iOS 13.0, *)

--- a/Sources/SFSymbols/Extensions/UIKeyCommand+Init.swift
+++ b/Sources/SFSymbols/Extensions/UIKeyCommand+Init.swift
@@ -4,7 +4,7 @@
 //  Generated from UIKit.framework
 //
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 import UIKit
 
 @available(iOS 13.0, *)

--- a/Sources/SFSymbols/Extensions/UIMenu+Init.swift
+++ b/Sources/SFSymbols/Extensions/UIMenu+Init.swift
@@ -4,7 +4,7 @@
 //  Generated from UIKit.framework
 //
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 import UIKit
 
 @available(iOS 13.0, tvOS 14.0, *)

--- a/Sources/SFSymbols/Extensions/UIWindowScene.ActivationAction+Init.swift
+++ b/Sources/SFSymbols/Extensions/UIWindowScene.ActivationAction+Init.swift
@@ -4,7 +4,7 @@
 //  Generated from UIKit.framework
 //
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 import UIKit
 
 @available(iOS 15.0, *)


### PR DESCRIPTION
## Problem

Under Xcode 26.5 / watchOS 26.5, `canImport(UIKit)` evaluates **true** on watchOS, so files guarded only by `#if canImport(UIKit)` still compile for watchOS — where `UIWindowScene`, `UIAction`, `UIMenu`, `UICommand`, and `UIKeyCommand` are unavailable. This breaks any watchOS target that depends on SFSymbols (e.g. via SwiftTools).

## Fix

Add `&& !os(watchOS)` to the guards in the 5 UIKit-only initializer files:

- `UIMenu+Init.swift`
- `UIAction+Init.swift`
- `UIKeyCommand+Init.swift`
- `UIWindowScene.ActivationAction+Init.swift`
- `UICommand+Init.swift`

This matches the stricter guards already used in `UIBarButtonItem+Init.swift` and `UIApplicationShortcutIconExtension.swift`. iOS / visionOS / Mac Catalyst are unaffected (they have UIKit and these symbols); watchOS is now correctly excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)