### PR TITLE
Apply full Draw category (2031 symbols) to generated sources

### DIFF
--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables13.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables13.swift
@@ -3624,7 +3624,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let antCircle = SFSymbol(
         title: "ant.circle",
-        categories: [.nature, .variable],
+        categories: [.nature, .variable, .draw],
         searchTerms: ["animals", "bug", "radar"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3856,7 +3856,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowClockwiseCircle = SFSymbol(
         title: "arrow.clockwise.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: ["refresh"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3867,7 +3867,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowClockwiseCircleFill = SFSymbol(
         title: "arrow.clockwise.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["refresh"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -3917,7 +3917,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowCounterclockwiseCircle = SFSymbol(
         title: "arrow.counterclockwise.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: ["revert"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3928,7 +3928,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowCounterclockwiseCircleFill = SFSymbol(
         title: "arrow.counterclockwise.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["revert"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -3978,7 +3978,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownCircle = SFSymbol(
         title: "arrow.down.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: ["download", "downloads"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3989,7 +3989,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownCircleFill = SFSymbol(
         title: "arrow.down.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["download", "downloads"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4039,7 +4039,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownLeftCircle = SFSymbol(
         title: "arrow.down.left.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4050,7 +4050,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownLeftCircleFill = SFSymbol(
         title: "arrow.down.left.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4061,7 +4061,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownLeftSquare = SFSymbol(
         title: "arrow.down.left.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4072,7 +4072,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownLeftSquareFill = SFSymbol(
         title: "arrow.down.left.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4084,7 +4084,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
     static let arrowDownLeftVideo = SFSymbol(
         title: "arrow.down.left.video",
-        categories: [.communication],
+        categories: [.communication, .draw],
         searchTerms: ["facetime"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -4097,7 +4097,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
     static let arrowDownLeftVideoFill = SFSymbol(
         title: "arrow.down.left.video.fill",
-        categories: [.communication, .multicolor],
+        categories: [.communication, .multicolor, .draw],
         searchTerms: ["facetime"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -4133,7 +4133,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownRightCircle = SFSymbol(
         title: "arrow.down.right.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4144,7 +4144,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownRightCircleFill = SFSymbol(
         title: "arrow.down.right.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4155,7 +4155,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownRightSquare = SFSymbol(
         title: "arrow.down.right.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4166,7 +4166,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownRightSquareFill = SFSymbol(
         title: "arrow.down.right.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4177,7 +4177,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownSquare = SFSymbol(
         title: "arrow.down.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["download", "downloads"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4188,7 +4188,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownSquareFill = SFSymbol(
         title: "arrow.down.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["download", "downloads"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4251,7 +4251,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowLeftAndRightCircle = SFSymbol(
         title: "arrow.left.and.right.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4262,7 +4262,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowLeftAndRightCircleFill = SFSymbol(
         title: "arrow.left.and.right.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4273,7 +4273,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowLeftAndRightSquare = SFSymbol(
         title: "arrow.left.and.right.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4284,7 +4284,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowLeftAndRightSquareFill = SFSymbol(
         title: "arrow.left.and.right.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4295,7 +4295,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowLeftCircle = SFSymbol(
         title: "arrow.left.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4306,7 +4306,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowLeftCircleFill = SFSymbol(
         title: "arrow.left.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4317,7 +4317,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowLeftSquare = SFSymbol(
         title: "arrow.left.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4328,7 +4328,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowLeftSquareFill = SFSymbol(
         title: "arrow.left.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4454,7 +4454,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowRightCircle = SFSymbol(
         title: "arrow.right.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4465,7 +4465,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowRightCircleFill = SFSymbol(
         title: "arrow.right.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4476,7 +4476,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowRightSquare = SFSymbol(
         title: "arrow.right.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4487,7 +4487,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowRightSquareFill = SFSymbol(
         title: "arrow.right.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4663,7 +4663,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpAndDownCircle = SFSymbol(
         title: "arrow.up.and.down.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4674,7 +4674,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpAndDownCircleFill = SFSymbol(
         title: "arrow.up.and.down.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4685,7 +4685,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpAndDownSquare = SFSymbol(
         title: "arrow.up.and.down.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4696,7 +4696,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpAndDownSquareFill = SFSymbol(
         title: "arrow.up.and.down.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4720,7 +4720,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpArrowDownCircle = SFSymbol(
         title: "arrow.up.arrow.down.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: ["sort"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4731,7 +4731,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpArrowDownCircleFill = SFSymbol(
         title: "arrow.up.arrow.down.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["sort"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4742,7 +4742,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpArrowDownSquare = SFSymbol(
         title: "arrow.up.arrow.down.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["sort"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4753,7 +4753,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpArrowDownSquareFill = SFSymbol(
         title: "arrow.up.arrow.down.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["sort"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4775,7 +4775,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpBinFill = SFSymbol(
         title: "arrow.up.bin.fill",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: ["mail"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4786,7 +4786,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpCircle = SFSymbol(
         title: "arrow.up.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4797,7 +4797,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpCircleFill = SFSymbol(
         title: "arrow.up.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4858,7 +4858,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpLeftCircle = SFSymbol(
         title: "arrow.up.left.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4869,7 +4869,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpLeftCircleFill = SFSymbol(
         title: "arrow.up.left.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4880,7 +4880,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpLeftSquare = SFSymbol(
         title: "arrow.up.left.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4891,7 +4891,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpLeftSquareFill = SFSymbol(
         title: "arrow.up.left.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4915,7 +4915,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpRightCircle = SFSymbol(
         title: "arrow.up.right.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4926,7 +4926,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpRightCircleFill = SFSymbol(
         title: "arrow.up.right.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4963,7 +4963,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpRightSquare = SFSymbol(
         title: "arrow.up.right.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4974,7 +4974,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpRightSquareFill = SFSymbol(
         title: "arrow.up.right.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4986,7 +4986,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
     static let arrowUpRightVideo = SFSymbol(
         title: "arrow.up.right.video",
-        categories: [.communication],
+        categories: [.communication, .draw],
         searchTerms: ["facetime"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -4999,7 +4999,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
     static let arrowUpRightVideoFill = SFSymbol(
         title: "arrow.up.right.video.fill",
-        categories: [.communication, .multicolor],
+        categories: [.communication, .multicolor, .draw],
         searchTerms: ["facetime"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -5011,7 +5011,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpSquare = SFSymbol(
         title: "arrow.up.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5022,7 +5022,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpSquareFill = SFSymbol(
         title: "arrow.up.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -5070,7 +5070,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUturnDownCircle = SFSymbol(
         title: "arrow.uturn.down.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5081,7 +5081,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUturnDownCircleFill = SFSymbol(
         title: "arrow.uturn.down.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -5092,7 +5092,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUturnDownSquare = SFSymbol(
         title: "arrow.uturn.down.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5103,7 +5103,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUturnDownSquareFill = SFSymbol(
         title: "arrow.uturn.down.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -5125,7 +5125,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUturnLeftCircle = SFSymbol(
         title: "arrow.uturn.left.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5136,7 +5136,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUturnLeftCircleFill = SFSymbol(
         title: "arrow.uturn.left.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -5147,7 +5147,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUturnLeftSquare = SFSymbol(
         title: "arrow.uturn.left.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5158,7 +5158,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUturnLeftSquareFill = SFSymbol(
         title: "arrow.uturn.left.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -5180,7 +5180,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUturnRightCircle = SFSymbol(
         title: "arrow.uturn.right.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5191,7 +5191,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUturnRightCircleFill = SFSymbol(
         title: "arrow.uturn.right.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -5202,7 +5202,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUturnRightSquare = SFSymbol(
         title: "arrow.uturn.right.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5213,7 +5213,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUturnRightSquareFill = SFSymbol(
         title: "arrow.uturn.right.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -5235,7 +5235,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUturnUpCircle = SFSymbol(
         title: "arrow.uturn.up.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5246,7 +5246,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUturnUpCircleFill = SFSymbol(
         title: "arrow.uturn.up.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -5257,7 +5257,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUturnUpSquare = SFSymbol(
         title: "arrow.uturn.up.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5268,7 +5268,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUturnUpSquareFill = SFSymbol(
         title: "arrow.uturn.up.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -5312,7 +5312,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowshapeTurnUpLeftCircle = SFSymbol(
         title: "arrowshape.turn.up.left.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: ["reply"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5356,7 +5356,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowshapeTurnUpRightCircle = SFSymbol(
         title: "arrowshape.turn.up.right.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: ["forward"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5402,7 +5402,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowtriangleDownCircle = SFSymbol(
         title: "arrowtriangle.down.circle",
-        categories: [.arrows, .gaming, .variable],
+        categories: [.arrows, .gaming, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5437,7 +5437,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowtriangleDownSquare = SFSymbol(
         title: "arrowtriangle.down.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5472,7 +5472,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowtriangleLeftCircle = SFSymbol(
         title: "arrowtriangle.left.circle",
-        categories: [.arrows, .gaming, .variable],
+        categories: [.arrows, .gaming, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5507,7 +5507,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowtriangleLeftSquare = SFSymbol(
         title: "arrowtriangle.left.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5542,7 +5542,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowtriangleRightCircle = SFSymbol(
         title: "arrowtriangle.right.circle",
-        categories: [.arrows, .gaming, .variable],
+        categories: [.arrows, .gaming, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5577,7 +5577,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowtriangleRightSquare = SFSymbol(
         title: "arrowtriangle.right.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5612,7 +5612,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowtriangleUpCircle = SFSymbol(
         title: "arrowtriangle.up.circle",
-        categories: [.arrows, .gaming, .variable],
+        categories: [.arrows, .gaming, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5647,7 +5647,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowtriangleUpSquare = SFSymbol(
         title: "arrowtriangle.up.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5670,7 +5670,7 @@ public extension SFSymbol {
     /// - Unicode: U+229B
     static let asteriskCircle = SFSymbol(
         title: "asterisk.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: ["*"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -5726,7 +5726,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let australsignCircle = SFSymbol(
         title: "australsign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5748,7 +5748,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let australsignSquare = SFSymbol(
         title: "australsign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5965,7 +5965,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let bahtsignCircle = SFSymbol(
         title: "bahtsign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5987,7 +5987,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let bahtsignSquare = SFSymbol(
         title: "bahtsign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6125,7 +6125,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let bellCircle = SFSymbol(
         title: "bell.circle",
-        categories: [.multicolor, .objectsAndTools, .variable],
+        categories: [.multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: ["mail", "notify"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -6158,7 +6158,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let bellSlash = SFSymbol(
         title: "bell.slash",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: ["mail", "remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -6169,7 +6169,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let bellSlashFill = SFSymbol(
         title: "bell.slash.fill",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: ["mail", "remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -6206,7 +6206,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let bitcoinsignCircle = SFSymbol(
         title: "bitcoinsign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6228,7 +6228,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let bitcoinsignSquare = SFSymbol(
         title: "bitcoinsign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6320,7 +6320,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let boltCircle = SFSymbol(
         title: "bolt.circle",
-        categories: [.cameraAndPhotos, .multicolor, .nature, .variable],
+        categories: [.cameraAndPhotos, .multicolor, .nature, .variable, .draw],
         searchTerms: ["camera", "energy", "power"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -6364,7 +6364,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let boltHorizontalCircle = SFSymbol(
         title: "bolt.horizontal.circle",
-        categories: [.connectivity, .variable],
+        categories: [.connectivity, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6423,7 +6423,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let boltSlash = SFSymbol(
         title: "bolt.slash",
-        categories: [.cameraAndPhotos, .multicolor, .nature],
+        categories: [.cameraAndPhotos, .multicolor, .nature, .draw],
         searchTerms: ["camera", "energy", "power", "remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -6434,7 +6434,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let boltSlashFill = SFSymbol(
         title: "bolt.slash.fill",
-        categories: [.cameraAndPhotos, .multicolor, .nature],
+        categories: [.cameraAndPhotos, .multicolor, .nature, .draw],
         searchTerms: ["camera", "energy", "power", "remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -6456,7 +6456,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let bookCircle = SFSymbol(
         title: "book.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["bookmark"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6761,7 +6761,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let calendarCircle = SFSymbol(
         title: "calendar.circle",
-        categories: [.multicolor, .objectsAndTools, .variable],
+        categories: [.multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: ["calendar", "date"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -6794,7 +6794,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cameraCircle = SFSymbol(
         title: "camera.circle",
-        categories: [.cameraAndPhotos, .objectsAndTools, .variable],
+        categories: [.cameraAndPhotos, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7031,7 +7031,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cedisignCircle = SFSymbol(
         title: "cedisign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7053,7 +7053,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cedisignSquare = SFSymbol(
         title: "cedisign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7075,7 +7075,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let centsignCircle = SFSymbol(
         title: "centsign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7097,7 +7097,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let centsignSquare = SFSymbol(
         title: "centsign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7130,7 +7130,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome
     static let chartBarFill = SFSymbol(
         title: "chart.bar.fill",
-        categories: [.connectivity, .variable],
+        categories: [.connectivity, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome]
@@ -7176,7 +7176,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let checkmarkCircle = SFSymbol(
         title: "checkmark.circle",
-        categories: [.multicolor, .privacyAndSecurity, .variable],
+        categories: [.multicolor, .privacyAndSecurity, .variable, .draw],
         searchTerms: ["select"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -7187,7 +7187,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let checkmarkCircleFill = SFSymbol(
         title: "checkmark.circle.fill",
-        categories: [.multicolor, .privacyAndSecurity],
+        categories: [.multicolor, .privacyAndSecurity, .draw],
         searchTerms: ["select"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -7198,7 +7198,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let checkmarkRectangle = SFSymbol(
         title: "checkmark.rectangle",
-        categories: [.privacyAndSecurity],
+        categories: [.privacyAndSecurity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7209,7 +7209,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let checkmarkRectangleFill = SFSymbol(
         title: "checkmark.rectangle.fill",
-        categories: [.multicolor, .privacyAndSecurity],
+        categories: [.multicolor, .privacyAndSecurity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -7220,7 +7220,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let checkmarkSeal = SFSymbol(
         title: "checkmark.seal",
-        categories: [.privacyAndSecurity],
+        categories: [.privacyAndSecurity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7231,7 +7231,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let checkmarkSealFill = SFSymbol(
         title: "checkmark.seal.fill",
-        categories: [.multicolor, .privacyAndSecurity],
+        categories: [.multicolor, .privacyAndSecurity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -7242,7 +7242,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let checkmarkShield = SFSymbol(
         title: "checkmark.shield",
-        categories: [.objectsAndTools, .privacyAndSecurity],
+        categories: [.objectsAndTools, .privacyAndSecurity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7253,7 +7253,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let checkmarkShieldFill = SFSymbol(
         title: "checkmark.shield.fill",
-        categories: [.multicolor, .objectsAndTools, .privacyAndSecurity],
+        categories: [.multicolor, .objectsAndTools, .privacyAndSecurity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -7265,7 +7265,7 @@ public extension SFSymbol {
     /// - Unicode: U+2611
     static let checkmarkSquare = SFSymbol(
         title: "checkmark.square",
-        categories: [.multicolor, .privacyAndSecurity],
+        categories: [.multicolor, .privacyAndSecurity, .draw],
         searchTerms: ["checkbox"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -7277,7 +7277,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let checkmarkSquareFill = SFSymbol(
         title: "checkmark.square.fill",
-        categories: [.multicolor, .privacyAndSecurity],
+        categories: [.multicolor, .privacyAndSecurity, .draw],
         searchTerms: ["checkbox"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -7343,7 +7343,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chevronDownCircle = SFSymbol(
         title: "chevron.down.circle",
-        categories: [.arrows, .cameraAndPhotos, .variable],
+        categories: [.arrows, .cameraAndPhotos, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7365,7 +7365,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chevronDownSquare = SFSymbol(
         title: "chevron.down.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7409,7 +7409,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chevronLeftCircle = SFSymbol(
         title: "chevron.left.circle",
-        categories: [.arrows, .cameraAndPhotos, .variable],
+        categories: [.arrows, .cameraAndPhotos, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7444,7 +7444,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chevronLeftSquare = SFSymbol(
         title: "chevron.left.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7488,7 +7488,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chevronRightCircle = SFSymbol(
         title: "chevron.right.circle",
-        categories: [.arrows, .cameraAndPhotos, .variable],
+        categories: [.arrows, .cameraAndPhotos, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7510,7 +7510,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chevronRightSquare = SFSymbol(
         title: "chevron.right.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7554,7 +7554,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chevronUpCircle = SFSymbol(
         title: "chevron.up.circle",
-        categories: [.arrows, .cameraAndPhotos, .variable],
+        categories: [.arrows, .cameraAndPhotos, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7576,7 +7576,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chevronUpSquare = SFSymbol(
         title: "chevron.up.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7823,7 +7823,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let cloudDrizzleFill = SFSymbol(
         title: "cloud.drizzle.fill",
-        categories: [.multicolor, .nature, .weather],
+        categories: [.multicolor, .nature, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -7856,7 +7856,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let cloudFogFill = SFSymbol(
         title: "cloud.fog.fill",
-        categories: [.multicolor, .nature, .weather],
+        categories: [.multicolor, .nature, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -7900,7 +7900,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let cloudHeavyrainFill = SFSymbol(
         title: "cloud.heavyrain.fill",
-        categories: [.multicolor, .nature, .weather],
+        categories: [.multicolor, .nature, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -7966,7 +7966,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let cloudMoonRainFill = SFSymbol(
         title: "cloud.moon.rain.fill",
-        categories: [.multicolor, .nature, .weather],
+        categories: [.multicolor, .nature, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -7988,7 +7988,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let cloudRainFill = SFSymbol(
         title: "cloud.rain.fill",
-        categories: [.multicolor, .nature, .weather],
+        categories: [.multicolor, .nature, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -8098,7 +8098,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let cloudSunRainFill = SFSymbol(
         title: "cloud.sun.rain.fill",
-        categories: [.multicolor, .nature, .weather],
+        categories: [.multicolor, .nature, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -8109,7 +8109,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let coloncurrencysignCircle = SFSymbol(
         title: "coloncurrencysign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8131,7 +8131,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let coloncurrencysignSquare = SFSymbol(
         title: "coloncurrencysign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8223,7 +8223,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cruzeirosignCircle = SFSymbol(
         title: "cruzeirosign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8245,7 +8245,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cruzeirosignSquare = SFSymbol(
         title: "cruzeirosign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8498,7 +8498,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let divideCircle = SFSymbol(
         title: "divide.circle",
-        categories: [.math, .variable],
+        categories: [.math, .variable, .draw],
         searchTerms: ["/", "÷"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8520,7 +8520,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let divideSquare = SFSymbol(
         title: "divide.square",
-        categories: [.math],
+        categories: [.math, .draw],
         searchTerms: ["/", "÷"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8741,7 +8741,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let dollarsignCircle = SFSymbol(
         title: "dollarsign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8763,7 +8763,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let dollarsignSquare = SFSymbol(
         title: "dollarsign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8785,7 +8785,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let dongsignCircle = SFSymbol(
         title: "dongsign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8807,7 +8807,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let dongsignSquare = SFSymbol(
         title: "dongsign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9021,7 +9021,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let ellipsisCircle = SFSymbol(
         title: "ellipsis.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: ["action", "dot.3", "extra", "more", "overflow", "…"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9076,7 +9076,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let envelopeCircle = SFSymbol(
         title: "envelope.circle",
-        categories: [.communication, .variable],
+        categories: [.communication, .variable, .draw],
         searchTerms: ["address", "letter", "mail"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9143,7 +9143,7 @@ public extension SFSymbol {
     /// - Unicode: U+229C
     static let equalCircle = SFSymbol(
         title: "equal.circle",
-        categories: [.math, .variable],
+        categories: [.math, .variable, .draw],
         searchTerms: ["="],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -9166,7 +9166,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let equalSquare = SFSymbol(
         title: "equal.square",
-        categories: [.math],
+        categories: [.math, .draw],
         searchTerms: ["="],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9201,7 +9201,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let eurosignCircle = SFSymbol(
         title: "eurosign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9223,7 +9223,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let eurosignSquare = SFSymbol(
         title: "eurosign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9278,7 +9278,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let exclamationmarkCircle = SFSymbol(
         title: "exclamationmark.circle",
-        categories: [.indices, .multicolor, .variable],
+        categories: [.indices, .multicolor, .variable, .draw],
         searchTerms: ["warning"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -9370,7 +9370,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let exclamationmarkSquare = SFSymbol(
         title: "exclamationmark.square",
-        categories: [.indices, .multicolor],
+        categories: [.indices, .multicolor, .draw],
         searchTerms: ["warning"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -9438,7 +9438,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let eyeSlash = SFSymbol(
         title: "eye.slash",
-        categories: [.accessibility, .health, .human, .privacyAndSecurity],
+        categories: [.accessibility, .health, .human, .privacyAndSecurity, .draw],
         searchTerms: ["hidden", "hide", "remove", "remove red eye"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9449,7 +9449,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let eyeSlashFill = SFSymbol(
         title: "eye.slash.fill",
-        categories: [.accessibility, .health, .human, .privacyAndSecurity],
+        categories: [.accessibility, .health, .human, .privacyAndSecurity, .draw],
         searchTerms: ["hidden", "hide", "remove", "remove red eye"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9541,7 +9541,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let fCursiveCircle = SFSymbol(
         title: "f.cursive.circle",
-        categories: [.cameraAndPhotos, .variable],
+        categories: [.cameraAndPhotos, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9635,7 +9635,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let flagCircle = SFSymbol(
         title: "flag.circle",
-        categories: [.multicolor, .objectsAndTools, .variable],
+        categories: [.multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: ["mail"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -9668,7 +9668,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let flagSlash = SFSymbol(
         title: "flag.slash",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: ["mail", "remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -9679,7 +9679,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let flagSlashFill = SFSymbol(
         title: "flag.slash.fill",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: ["mail", "remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -9712,7 +9712,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let florinsignCircle = SFSymbol(
         title: "florinsign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9734,7 +9734,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let florinsignSquare = SFSymbol(
         title: "florinsign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9822,7 +9822,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let folderCircle = SFSymbol(
         title: "folder.circle",
-        categories: [.multicolor, .objectsAndTools, .variable],
+        categories: [.multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: ["move"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -9954,7 +9954,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let francsignCircle = SFSymbol(
         title: "francsign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9976,7 +9976,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let francsignSquare = SFSymbol(
         title: "francsign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10452,7 +10452,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let greaterthanCircle = SFSymbol(
         title: "greaterthan.circle",
-        categories: [.math, .variable],
+        categories: [.math, .variable, .draw],
         searchTerms: [">"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10474,7 +10474,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let greaterthanSquare = SFSymbol(
         title: "greaterthan.square",
-        categories: [.math],
+        categories: [.math, .draw],
         searchTerms: [">"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10507,7 +10507,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let gridCircle = SFSymbol(
         title: "grid.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10529,7 +10529,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let guaranisignCircle = SFSymbol(
         title: "guaranisign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10551,7 +10551,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let guaranisignSquare = SFSymbol(
         title: "guaranisign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10746,7 +10746,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let handRaisedSlash = SFSymbol(
         title: "hand.raised.slash",
-        categories: [.human, .multicolor, .privacyAndSecurity],
+        categories: [.human, .multicolor, .privacyAndSecurity, .draw],
         searchTerms: ["privacy", "remove", "unblock"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -10757,7 +10757,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let handRaisedSlashFill = SFSymbol(
         title: "hand.raised.slash.fill",
-        categories: [.human, .privacyAndSecurity],
+        categories: [.human, .privacyAndSecurity, .draw],
         searchTerms: ["privacy", "remove", "unblock"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10856,7 +10856,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let heartCircle = SFSymbol(
         title: "heart.circle",
-        categories: [.health, .multicolor, .variable],
+        categories: [.health, .multicolor, .variable, .draw],
         searchTerms: ["love", "medical"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -10889,7 +10889,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let heartSlash = SFSymbol(
         title: "heart.slash",
-        categories: [.multicolor, .variable],
+        categories: [.multicolor, .variable, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -10900,7 +10900,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let heartSlashCircle = SFSymbol(
         title: "heart.slash.circle",
-        categories: [.multicolor, .variable],
+        categories: [.multicolor, .variable, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -10922,7 +10922,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let heartSlashFill = SFSymbol(
         title: "heart.slash.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -11051,7 +11051,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let hryvniasignCircle = SFSymbol(
         title: "hryvniasign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11073,7 +11073,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let hryvniasignSquare = SFSymbol(
         title: "hryvniasign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11185,7 +11185,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
     static let icloudAndArrowDownFill = SFSymbol(
         title: "icloud.and.arrow.down.fill",
-        categories: [.connectivity],
+        categories: [.connectivity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -11224,7 +11224,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
     static let icloudCircle = SFSymbol(
         title: "icloud.circle",
-        categories: [.connectivity, .multicolor, .variable],
+        categories: [.connectivity, .multicolor, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -11263,7 +11263,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
     static let icloudSlash = SFSymbol(
         title: "icloud.slash",
-        categories: [.connectivity, .multicolor],
+        categories: [.connectivity, .multicolor, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -11276,7 +11276,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
     static let icloudSlashFill = SFSymbol(
         title: "icloud.slash.fill",
-        categories: [.connectivity, .multicolor],
+        categories: [.connectivity, .multicolor, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -11310,7 +11310,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let indianrupeesignCircle = SFSymbol(
         title: "indianrupeesign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11332,7 +11332,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let indianrupeesignSquare = SFSymbol(
         title: "indianrupeesign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11365,7 +11365,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let infoCircle = SFSymbol(
         title: "info.circle",
-        categories: [.multicolor, .variable],
+        categories: [.multicolor, .variable, .draw],
         searchTerms: ["info"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -11451,7 +11451,7 @@ public extension SFSymbol {
     /// - Unicode: U+24C0
     static let kCircle = SFSymbol(
         title: "k.circle",
-        categories: [.indices, .variable],
+        categories: [.indices, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -11477,7 +11477,7 @@ public extension SFSymbol {
     /// - Unicode: U+1F13A
     static let kSquare = SFSymbol(
         title: "k.square",
-        categories: [.indices],
+        categories: [.indices, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -11524,7 +11524,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let kipsignCircle = SFSymbol(
         title: "kipsign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11546,7 +11546,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let kipsignSquare = SFSymbol(
         title: "kipsign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11633,7 +11633,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let larisignCircle = SFSymbol(
         title: "larisign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11655,7 +11655,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let larisignSquare = SFSymbol(
         title: "larisign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11712,7 +11712,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let lessthanCircle = SFSymbol(
         title: "lessthan.circle",
-        categories: [.math, .variable],
+        categories: [.math, .variable, .draw],
         searchTerms: ["<"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11734,7 +11734,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let lessthanSquare = SFSymbol(
         title: "lessthan.square",
-        categories: [.math],
+        categories: [.math, .draw],
         searchTerms: ["<"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11800,7 +11800,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let lightbulbSlash = SFSymbol(
         title: "lightbulb.slash",
-        categories: [.home, .objectsAndTools],
+        categories: [.home, .objectsAndTools, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11885,7 +11885,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let linkCircle = SFSymbol(
         title: "link.circle",
-        categories: [.multicolor, .objectsAndTools, .variable],
+        categories: [.multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -11933,7 +11933,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let lirasignCircle = SFSymbol(
         title: "lirasign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11955,7 +11955,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let lirasignSquare = SFSymbol(
         title: "lirasign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -12084,7 +12084,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let locationCircle = SFSymbol(
         title: "location.circle",
-        categories: [.arrows, .maps, .multicolor, .variable],
+        categories: [.arrows, .maps, .multicolor, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -12161,7 +12161,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let locationSlash = SFSymbol(
         title: "location.slash",
-        categories: [.arrows, .maps, .multicolor],
+        categories: [.arrows, .maps, .multicolor, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -12172,7 +12172,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let locationSlashFill = SFSymbol(
         title: "location.slash.fill",
-        categories: [.arrows, .maps, .multicolor],
+        categories: [.arrows, .maps, .multicolor, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -12194,7 +12194,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let lockCircle = SFSymbol(
         title: "lock.circle",
-        categories: [.multicolor, .objectsAndTools, .privacyAndSecurity, .variable],
+        categories: [.multicolor, .objectsAndTools, .privacyAndSecurity, .variable, .draw],
         searchTerms: ["lock", "padlock", "password", "security"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -12321,7 +12321,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let lockSlash = SFSymbol(
         title: "lock.slash",
-        categories: [.multicolor, .objectsAndTools, .privacyAndSecurity],
+        categories: [.multicolor, .objectsAndTools, .privacyAndSecurity, .draw],
         searchTerms: ["padlock", "password", "remove", "security"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -12332,7 +12332,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let lockSlashFill = SFSymbol(
         title: "lock.slash.fill",
-        categories: [.multicolor, .objectsAndTools, .privacyAndSecurity],
+        categories: [.multicolor, .objectsAndTools, .privacyAndSecurity, .draw],
         searchTerms: ["padlock", "password", "remove", "security"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -12417,7 +12417,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let magnifyingglassCircle = SFSymbol(
         title: "magnifyingglass.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["search"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -12439,7 +12439,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let manatsignCircle = SFSymbol(
         title: "manatsign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -12461,7 +12461,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let manatsignSquare = SFSymbol(
         title: "manatsign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -12585,7 +12585,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Messages app.
     static let messageCircle = SFSymbol(
         title: "message.circle",
-        categories: [.communication, .multicolor, .variable],
+        categories: [.communication, .multicolor, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -12712,7 +12712,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let millsignCircle = SFSymbol(
         title: "millsign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -12734,7 +12734,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let millsignSquare = SFSymbol(
         title: "millsign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -12768,7 +12768,7 @@ public extension SFSymbol {
     /// - Unicode: U+2296, U+229D
     static let minusCircle = SFSymbol(
         title: "minus.circle",
-        categories: [.gaming, .math, .multicolor, .variable],
+        categories: [.gaming, .math, .multicolor, .variable, .draw],
         searchTerms: ["-", "decrease", "delete", "minus", "remove", "subtract", "−"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -12780,7 +12780,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let minusCircleFill = SFSymbol(
         title: "minus.circle.fill",
-        categories: [.gaming, .math, .multicolor],
+        categories: [.gaming, .math, .multicolor, .draw],
         searchTerms: ["-", "decrease", "delete", "minus", "remove", "subtract", "−"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -12802,7 +12802,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let minusRectangle = SFSymbol(
         title: "minus.rectangle",
-        categories: [.math, .multicolor],
+        categories: [.math, .multicolor, .draw],
         searchTerms: ["-", "decrease", "delete", "minus", "remove", "subtract", "−"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -12813,7 +12813,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let minusRectangleFill = SFSymbol(
         title: "minus.rectangle.fill",
-        categories: [.math, .multicolor],
+        categories: [.math, .multicolor, .draw],
         searchTerms: ["-", "decrease", "delete", "minus", "remove", "subtract", "−"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -12837,7 +12837,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let minusSquare = SFSymbol(
         title: "minus.square",
-        categories: [.math, .multicolor],
+        categories: [.math, .multicolor, .draw],
         searchTerms: ["-", "decrease", "delete", "minus", "remove", "subtract", "−"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -12848,7 +12848,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let minusSquareFill = SFSymbol(
         title: "minus.square.fill",
-        categories: [.math, .multicolor],
+        categories: [.math, .multicolor, .draw],
         searchTerms: ["-", "decrease", "delete", "minus", "remove", "subtract", "−"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -12870,7 +12870,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let moonCircle = SFSymbol(
         title: "moon.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["dnd", "do not disturb", "weather"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -12961,7 +12961,7 @@ public extension SFSymbol {
     /// - Unicode: U+2297
     static let multiplyCircle = SFSymbol(
         title: "multiply.circle",
-        categories: [.math, .variable],
+        categories: [.math, .variable, .draw],
         searchTerms: ["*", "multiply", "times"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -12973,7 +12973,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let multiplyCircleFill = SFSymbol(
         title: "multiply.circle.fill",
-        categories: [.math, .multicolor],
+        categories: [.math, .multicolor, .draw],
         searchTerms: ["*", "multiply", "times"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -12984,7 +12984,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let multiplySquare = SFSymbol(
         title: "multiply.square",
-        categories: [.math],
+        categories: [.math, .draw],
         searchTerms: ["*", "multiply", "times"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -12995,7 +12995,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let multiplySquareFill = SFSymbol(
         title: "multiply.square.fill",
-        categories: [.math, .multicolor],
+        categories: [.math, .multicolor, .draw],
         searchTerms: ["*", "multiply", "times"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -13119,7 +13119,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let nairasignCircle = SFSymbol(
         title: "nairasign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -13141,7 +13141,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let nairasignSquare = SFSymbol(
         title: "nairasign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -13447,7 +13447,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pauseCircle = SFSymbol(
         title: "pause.circle",
-        categories: [.media, .variable],
+        categories: [.media, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -13480,7 +13480,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pauseRectangle = SFSymbol(
         title: "pause.rectangle",
-        categories: [.media],
+        categories: [.media, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -13537,7 +13537,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pencilCircle = SFSymbol(
         title: "pencil.circle",
-        categories: [.editing, .objectsAndTools, .variable],
+        categories: [.editing, .objectsAndTools, .variable, .draw],
         searchTerms: ["write", "writing"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -13559,7 +13559,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pencilSlash = SFSymbol(
         title: "pencil.slash",
-        categories: [.editing, .objectsAndTools],
+        categories: [.editing, .objectsAndTools, .draw],
         searchTerms: ["remove", "write", "writing"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -13764,7 +13764,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let personCircle = SFSymbol(
         title: "person.circle",
-        categories: [.human, .variable],
+        categories: [.human, .variable, .draw],
         searchTerms: ["people", "user"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -14025,7 +14025,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pesetasignCircle = SFSymbol(
         title: "pesetasign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -14047,7 +14047,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pesetasignSquare = SFSymbol(
         title: "pesetasign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -14069,7 +14069,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pesosignCircle = SFSymbol(
         title: "pesosign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -14091,7 +14091,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pesosignSquare = SFSymbol(
         title: "pesosign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -14168,7 +14168,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let phoneCircle = SFSymbol(
         title: "phone.circle",
-        categories: [.communication, .multicolor, .variable],
+        categories: [.communication, .multicolor, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -14201,7 +14201,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let phoneDownCircle = SFSymbol(
         title: "phone.down.circle",
-        categories: [.communication, .multicolor, .variable],
+        categories: [.communication, .multicolor, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -14361,7 +14361,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let pinSlash = SFSymbol(
         title: "pin.slash",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -14372,7 +14372,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let pinSlashFill = SFSymbol(
         title: "pin.slash.fill",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -14394,7 +14394,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let playCircle = SFSymbol(
         title: "play.circle",
-        categories: [.media, .variable],
+        categories: [.media, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -14427,7 +14427,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let playRectangle = SFSymbol(
         title: "play.rectangle",
-        categories: [.media],
+        categories: [.media, .draw],
         searchTerms: ["slideshow"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -14482,7 +14482,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let plusApp = SFSymbol(
         title: "plus.app",
-        categories: nil,
+        categories: [.draw],
         searchTerms: ["add"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -14493,7 +14493,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let plusAppFill = SFSymbol(
         title: "plus.app.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["add"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -14504,7 +14504,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let plusBubble = SFSymbol(
         title: "plus.bubble",
-        categories: [.communication],
+        categories: [.communication, .draw],
         searchTerms: ["add"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -14515,7 +14515,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let plusBubbleFill = SFSymbol(
         title: "plus.bubble.fill",
-        categories: [.communication, .multicolor],
+        categories: [.communication, .multicolor, .draw],
         searchTerms: ["add"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -14527,7 +14527,7 @@ public extension SFSymbol {
     /// - Unicode: U+2295
     static let plusCircle = SFSymbol(
         title: "plus.circle",
-        categories: [.gaming, .math, .multicolor, .variable],
+        categories: [.gaming, .math, .multicolor, .variable, .draw],
         searchTerms: ["+", "add", "create", "increase", "new", "plus"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -14539,7 +14539,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let plusCircleFill = SFSymbol(
         title: "plus.circle.fill",
-        categories: [.gaming, .math, .multicolor],
+        categories: [.gaming, .math, .multicolor, .draw],
         searchTerms: ["+", "add", "create", "increase", "new", "plus"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -14561,7 +14561,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let plusRectangle = SFSymbol(
         title: "plus.rectangle",
-        categories: [.math, .multicolor],
+        categories: [.math, .multicolor, .draw],
         searchTerms: ["+", "add", "create", "increase", "new", "plus"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -14572,7 +14572,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let plusRectangleFill = SFSymbol(
         title: "plus.rectangle.fill",
-        categories: [.math, .multicolor],
+        categories: [.math, .multicolor, .draw],
         searchTerms: ["+", "add", "create", "increase", "new", "plus"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -14618,7 +14618,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let plusSquare = SFSymbol(
         title: "plus.square",
-        categories: [.math, .multicolor],
+        categories: [.math, .multicolor, .draw],
         searchTerms: ["+", "add", "create", "increase", "new", "plus"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -14629,7 +14629,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let plusSquareFill = SFSymbol(
         title: "plus.square.fill",
-        categories: [.math, .multicolor],
+        categories: [.math, .multicolor, .draw],
         searchTerms: ["+", "add", "create", "increase", "new", "plus"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -14640,7 +14640,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let plusSquareFillOnSquareFill = SFSymbol(
         title: "plus.square.fill.on.square.fill",
-        categories: nil,
+        categories: [.draw],
         searchTerms: ["add", "duplicate"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -14651,7 +14651,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let plusSquareOnSquare = SFSymbol(
         title: "plus.square.on.square",
-        categories: nil,
+        categories: [.draw],
         searchTerms: ["add", "duplicate"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -14673,7 +14673,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let plusminusCircle = SFSymbol(
         title: "plusminus.circle",
-        categories: [.cameraAndPhotos, .math, .variable],
+        categories: [.cameraAndPhotos, .math, .variable, .draw],
         searchTerms: ["add", "remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -14684,7 +14684,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let plusminusCircleFill = SFSymbol(
         title: "plusminus.circle.fill",
-        categories: [.cameraAndPhotos, .math, .multicolor],
+        categories: [.cameraAndPhotos, .math, .multicolor, .draw],
         searchTerms: ["add", "remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -14754,7 +14754,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let purchasedCircle = SFSymbol(
         title: "purchased.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -14864,7 +14864,7 @@ public extension SFSymbol {
     /// - Localizations: Arabic
     static let questionmarkCircle = SFSymbol(
         title: "questionmark.circle",
-        categories: [.indices, .multicolor, .variable],
+        categories: [.indices, .multicolor, .variable, .draw],
         searchTerms: ["help"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -14918,7 +14918,7 @@ public extension SFSymbol {
     /// - Localizations: Arabic
     static let questionmarkSquare = SFSymbol(
         title: "questionmark.square",
-        categories: [.indices, .multicolor],
+        categories: [.indices, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -15610,7 +15610,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rotateLeftFill = SFSymbol(
         title: "rotate.left.fill",
-        categories: [.editing],
+        categories: [.editing, .draw],
         searchTerms: ["rotate left"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -15632,7 +15632,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rotateRightFill = SFSymbol(
         title: "rotate.right.fill",
-        categories: [.editing],
+        categories: [.editing, .draw],
         searchTerms: ["rotate right"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -15643,7 +15643,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rublesignCircle = SFSymbol(
         title: "rublesign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -15665,7 +15665,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rublesignSquare = SFSymbol(
         title: "rublesign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -15687,7 +15687,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rupeesignCircle = SFSymbol(
         title: "rupeesign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -15709,7 +15709,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rupeesignSquare = SFSymbol(
         title: "rupeesign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -15940,7 +15940,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let shieldSlash = SFSymbol(
         title: "shield.slash",
-        categories: [.objectsAndTools, .privacyAndSecurity],
+        categories: [.objectsAndTools, .privacyAndSecurity, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -15951,7 +15951,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let shieldSlashFill = SFSymbol(
         title: "shield.slash.fill",
-        categories: [.objectsAndTools, .privacyAndSecurity],
+        categories: [.objectsAndTools, .privacyAndSecurity, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -16323,7 +16323,7 @@ public extension SFSymbol {
     /// - Localizations: Right-to-Left
     static let speakerSlash = SFSymbol(
         title: "speaker.slash",
-        categories: [.objectsAndTools],
+        categories: [.objectsAndTools, .draw],
         searchTerms: ["mute", "remove", "volume"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -16336,7 +16336,7 @@ public extension SFSymbol {
     /// - Localizations: Right-to-Left
     static let speakerSlashFill = SFSymbol(
         title: "speaker.slash.fill",
-        categories: [.objectsAndTools],
+        categories: [.objectsAndTools, .draw],
         searchTerms: ["mute", "remove", "volume"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -16904,7 +16904,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let starCircle = SFSymbol(
         title: "star.circle",
-        categories: [.multicolor, .variable],
+        categories: [.multicolor, .variable, .draw],
         searchTerms: ["favorite"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -16952,7 +16952,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let starSlash = SFSymbol(
         title: "star.slash",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["favorite", "remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -16963,7 +16963,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let starSlashFill = SFSymbol(
         title: "star.slash.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["favorite", "remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -16996,7 +16996,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sterlingsignCircle = SFSymbol(
         title: "sterlingsign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -17018,7 +17018,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sterlingsignSquare = SFSymbol(
         title: "sterlingsign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -17051,7 +17051,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let stopCircle = SFSymbol(
         title: "stop.circle",
-        categories: [.media, .variable],
+        categories: [.media, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -17289,7 +17289,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, multicolor
     static let sunMaxFill = SFSymbol(
         title: "sun.max.fill",
-        categories: [.keyboard, .multicolor, .nature, .weather],
+        categories: [.keyboard, .multicolor, .nature, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .multicolor]
@@ -17511,7 +17511,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tagCircle = SFSymbol(
         title: "tag.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -17570,7 +17570,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tengesignCircle = SFSymbol(
         title: "tengesign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -17592,7 +17592,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tengesignSquare = SFSymbol(
         title: "tengesign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -17729,7 +17729,7 @@ public extension SFSymbol {
     /// - Localizations: Right-to-Left
     static let textBubbleFill = SFSymbol(
         title: "text.bubble.fill",
-        categories: [.communication, .multicolor],
+        categories: [.communication, .multicolor, .draw],
         searchTerms: ["speech"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -18050,7 +18050,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let trashCircle = SFSymbol(
         title: "trash.circle",
-        categories: [.multicolor, .objectsAndTools, .variable],
+        categories: [.multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: ["mail", "trash"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -18083,7 +18083,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let trashSlash = SFSymbol(
         title: "trash.slash",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -18094,7 +18094,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let trashSlashFill = SFSymbol(
         title: "trash.slash.fill",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -18149,7 +18149,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let trayAndArrowDownFill = SFSymbol(
         title: "tray.and.arrow.down.fill",
-        categories: [.objectsAndTools],
+        categories: [.objectsAndTools, .draw],
         searchTerms: ["mail"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -18171,7 +18171,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let trayAndArrowUpFill = SFSymbol(
         title: "tray.and.arrow.up.fill",
-        categories: [.objectsAndTools],
+        categories: [.objectsAndTools, .draw],
         searchTerms: ["mail"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -18276,7 +18276,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tugriksignCircle = SFSymbol(
         title: "tugriksign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -18298,7 +18298,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tugriksignSquare = SFSymbol(
         title: "tugriksign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -18331,7 +18331,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let turkishlirasignCircle = SFSymbol(
         title: "turkishlirasign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -18353,7 +18353,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let turkishlirasignSquare = SFSymbol(
         title: "turkishlirasign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -18386,7 +18386,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tvCircle = SFSymbol(
         title: "tv.circle",
-        categories: [.devices, .variable],
+        categories: [.devices, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -18635,7 +18635,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
     static let videoCircle = SFSymbol(
         title: "video.circle",
-        categories: [.communication, .multicolor, .variable],
+        categories: [.communication, .multicolor, .variable, .draw],
         searchTerms: ["facetime"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -18674,7 +18674,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
     static let videoSlash = SFSymbol(
         title: "video.slash",
-        categories: [.communication, .multicolor],
+        categories: [.communication, .multicolor, .draw],
         searchTerms: ["facetime", "remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -18687,7 +18687,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
     static let videoSlashFill = SFSymbol(
         title: "video.slash.fill",
-        categories: [.communication, .multicolor],
+        categories: [.communication, .multicolor, .draw],
         searchTerms: ["facetime", "remove"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -18732,7 +18732,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let viewfinderCircle = SFSymbol(
         title: "viewfinder.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -18817,7 +18817,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let wandAndRaysInverse = SFSymbol(
         title: "wand.and.rays.inverse",
-        categories: [.editing, .objectsAndTools, .variable],
+        categories: [.editing, .objectsAndTools, .variable, .draw],
         searchTerms: ["magic"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -18865,7 +18865,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let waveformCircle = SFSymbol(
         title: "waveform.circle",
-        categories: [.communication, .maps, .variable],
+        categories: [.communication, .maps, .variable, .draw],
         searchTerms: ["audio", "high", "record", "speech", "voice memo"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -18876,7 +18876,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let waveformCircleFill = SFSymbol(
         title: "waveform.circle.fill",
-        categories: [.communication, .maps, .multicolor, .variable],
+        categories: [.communication, .maps, .multicolor, .variable, .draw],
         searchTerms: ["audio", "high", "record", "speech", "voice memo"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -18986,7 +18986,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let wonsignCircle = SFSymbol(
         title: "wonsign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -19008,7 +19008,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let wonsignSquare = SFSymbol(
         title: "wonsign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -19134,7 +19134,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let xmarkCircle = SFSymbol(
         title: "xmark.circle",
-        categories: [.gaming, .multicolor, .variable],
+        categories: [.gaming, .multicolor, .variable, .draw],
         searchTerms: ["clear", "close", "stop", "x"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -19145,7 +19145,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let xmarkCircleFill = SFSymbol(
         title: "xmark.circle.fill",
-        categories: [.gaming, .multicolor],
+        categories: [.gaming, .multicolor, .draw],
         searchTerms: ["clear", "close", "stop", "x"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -19157,7 +19157,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
     static let xmarkIcloud = SFSymbol(
         title: "xmark.icloud",
-        categories: [.connectivity],
+        categories: [.connectivity, .draw],
         searchTerms: ["x"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -19170,7 +19170,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
     static let xmarkIcloudFill = SFSymbol(
         title: "xmark.icloud.fill",
-        categories: [.connectivity, .multicolor],
+        categories: [.connectivity, .multicolor, .draw],
         searchTerms: ["x"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -19193,7 +19193,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let xmarkOctagonFill = SFSymbol(
         title: "xmark.octagon.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["*", "multiply", "times"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -19204,7 +19204,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let xmarkRectangle = SFSymbol(
         title: "xmark.rectangle",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["x"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -19215,7 +19215,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let xmarkRectangleFill = SFSymbol(
         title: "xmark.rectangle.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["x"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -19226,7 +19226,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let xmarkSeal = SFSymbol(
         title: "xmark.seal",
-        categories: [.privacyAndSecurity],
+        categories: [.privacyAndSecurity, .draw],
         searchTerms: ["*", "multiply", "times"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -19237,7 +19237,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let xmarkSealFill = SFSymbol(
         title: "xmark.seal.fill",
-        categories: [.multicolor, .privacyAndSecurity],
+        categories: [.multicolor, .privacyAndSecurity, .draw],
         searchTerms: ["*", "multiply", "times"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -19248,7 +19248,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let xmarkShield = SFSymbol(
         title: "xmark.shield",
-        categories: [.multicolor, .objectsAndTools, .privacyAndSecurity],
+        categories: [.multicolor, .objectsAndTools, .privacyAndSecurity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -19259,7 +19259,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let xmarkShieldFill = SFSymbol(
         title: "xmark.shield.fill",
-        categories: [.multicolor, .objectsAndTools, .privacyAndSecurity],
+        categories: [.multicolor, .objectsAndTools, .privacyAndSecurity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -19271,7 +19271,7 @@ public extension SFSymbol {
     /// - Unicode: U+2612
     static let xmarkSquare = SFSymbol(
         title: "xmark.square",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["clear", "close", "stop", "x"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -19283,7 +19283,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let xmarkSquareFill = SFSymbol(
         title: "xmark.square.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["clear", "close", "stop", "x"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -19346,7 +19346,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let yensignCircle = SFSymbol(
         title: "yensign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -19368,7 +19368,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let yensignSquare = SFSymbol(
         title: "yensign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 13.0, macOS: 10.15, tvOS: 13.0, watchOS: 6.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables13P1.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables13P1.swift
@@ -127,7 +127,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let mappinCircle = SFSymbol(
         title: "mappin.circle",
-        categories: [.maps, .multicolor, .objectsAndTools, .variable],
+        categories: [.maps, .multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 13.1, macOS: 10.15, tvOS: 13.0, watchOS: 6.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -149,7 +149,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let paperclipCircle = SFSymbol(
         title: "paperclip.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["attach", "attachments"],
         releaseInfo: ReleaseInfo(iOS: 13.1, macOS: 10.15, tvOS: 13.0, watchOS: 6.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -160,7 +160,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let paperclipCircleFill = SFSymbol(
         title: "paperclip.circle.fill",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: ["attach", "attachments"],
         releaseInfo: ReleaseInfo(iOS: 13.1, macOS: 10.15, tvOS: 13.0, watchOS: 6.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -171,7 +171,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let pinCircle = SFSymbol(
         title: "pin.circle",
-        categories: [.multicolor, .objectsAndTools, .variable],
+        categories: [.multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: ["pin"],
         releaseInfo: ReleaseInfo(iOS: 13.1, macOS: 10.15, tvOS: 13.0, watchOS: 6.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables14.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables14.swift
@@ -91,7 +91,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let airplaneCircle = SFSymbol(
         title: "airplane.circle",
-        categories: [.multicolor, .transportation, .variable],
+        categories: [.multicolor, .transportation, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -438,7 +438,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let archiveboxCircle = SFSymbol(
         title: "archivebox.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["archive"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -471,7 +471,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowBackwardCircle = SFSymbol(
         title: "arrow.backward.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -482,7 +482,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowBackwardCircleFill = SFSymbol(
         title: "arrow.backward.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -493,7 +493,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowBackwardSquare = SFSymbol(
         title: "arrow.backward.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -504,7 +504,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowBackwardSquareFill = SFSymbol(
         title: "arrow.backward.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -541,7 +541,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownApp = SFSymbol(
         title: "arrow.down.app",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -552,7 +552,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownAppFill = SFSymbol(
         title: "arrow.down.app.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -574,7 +574,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownBackwardCircle = SFSymbol(
         title: "arrow.down.backward.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -585,7 +585,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownBackwardCircleFill = SFSymbol(
         title: "arrow.down.backward.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -596,7 +596,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownBackwardSquare = SFSymbol(
         title: "arrow.down.backward.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -607,7 +607,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownBackwardSquareFill = SFSymbol(
         title: "arrow.down.backward.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -640,7 +640,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownForwardAndArrowUpBackwardCircle = SFSymbol(
         title: "arrow.down.forward.and.arrow.up.backward.circle",
-        categories: [.arrows, .cameraAndPhotos, .variable],
+        categories: [.arrows, .cameraAndPhotos, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -662,7 +662,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownForwardCircle = SFSymbol(
         title: "arrow.down.forward.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -673,7 +673,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownForwardCircleFill = SFSymbol(
         title: "arrow.down.forward.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -684,7 +684,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownForwardSquare = SFSymbol(
         title: "arrow.down.forward.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -695,7 +695,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownForwardSquareFill = SFSymbol(
         title: "arrow.down.forward.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -717,7 +717,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownHeartFill = SFSymbol(
         title: "arrow.down.heart.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -728,7 +728,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownRightAndArrowUpLeftCircle = SFSymbol(
         title: "arrow.down.right.and.arrow.up.left.circle",
-        categories: [.arrows, .cameraAndPhotos, .variable],
+        categories: [.arrows, .cameraAndPhotos, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -761,7 +761,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowForwardCircle = SFSymbol(
         title: "arrow.forward.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -772,7 +772,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowForwardCircleFill = SFSymbol(
         title: "arrow.forward.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -783,7 +783,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowForwardSquare = SFSymbol(
         title: "arrow.forward.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -794,7 +794,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowForwardSquareFill = SFSymbol(
         title: "arrow.forward.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -842,7 +842,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowLeftArrowRightCircle = SFSymbol(
         title: "arrow.left.arrow.right.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -853,7 +853,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowLeftArrowRightCircleFill = SFSymbol(
         title: "arrow.left.arrow.right.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -864,7 +864,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowLeftArrowRightSquare = SFSymbol(
         title: "arrow.left.arrow.right.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -875,7 +875,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowLeftArrowRightSquareFill = SFSymbol(
         title: "arrow.left.arrow.right.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1118,7 +1118,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowTurnUpForwardIphoneFill = SFSymbol(
         title: "arrow.turn.up.forward.iphone.fill",
-        categories: [.devices],
+        categories: [.devices, .draw],
         searchTerms: ["pickups"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1221,7 +1221,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpBackwardAndArrowDownForwardCircle = SFSymbol(
         title: "arrow.up.backward.and.arrow.down.forward.circle",
-        categories: [.arrows, .cameraAndPhotos, .variable],
+        categories: [.arrows, .cameraAndPhotos, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1243,7 +1243,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpBackwardCircle = SFSymbol(
         title: "arrow.up.backward.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1254,7 +1254,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpBackwardCircleFill = SFSymbol(
         title: "arrow.up.backward.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1265,7 +1265,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpBackwardSquare = SFSymbol(
         title: "arrow.up.backward.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1276,7 +1276,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpBackwardSquareFill = SFSymbol(
         title: "arrow.up.backward.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1322,7 +1322,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpForwardAppFill = SFSymbol(
         title: "arrow.up.forward.app.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1333,7 +1333,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpForwardCircle = SFSymbol(
         title: "arrow.up.forward.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1344,7 +1344,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpForwardCircleFill = SFSymbol(
         title: "arrow.up.forward.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1355,7 +1355,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpForwardSquare = SFSymbol(
         title: "arrow.up.forward.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1366,7 +1366,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpForwardSquareFill = SFSymbol(
         title: "arrow.up.forward.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1388,7 +1388,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpHeartFill = SFSymbol(
         title: "arrow.up.heart.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1399,7 +1399,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpLeftAndArrowDownRightCircle = SFSymbol(
         title: "arrow.up.left.and.arrow.down.right.circle",
-        categories: [.arrows, .cameraAndPhotos, .variable],
+        categories: [.arrows, .cameraAndPhotos, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1457,7 +1457,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Messages app.
     static let arrowUpMessageFill = SFSymbol(
         title: "arrow.up.message.fill",
-        categories: [.communication, .multicolor],
+        categories: [.communication, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -1469,7 +1469,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpRightAndArrowDownLeftRectangle = SFSymbol(
         title: "arrow.up.right.and.arrow.down.left.rectangle",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["conversations"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1480,7 +1480,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpRightAndArrowDownLeftRectangleFill = SFSymbol(
         title: "arrow.up.right.and.arrow.down.left.rectangle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["conversations"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1502,7 +1502,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUturnBackwardCircle = SFSymbol(
         title: "arrow.uturn.backward.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: ["left", "undo"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1524,7 +1524,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUturnBackwardCircleFill = SFSymbol(
         title: "arrow.uturn.backward.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["left", "undo"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1535,7 +1535,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUturnBackwardSquare = SFSymbol(
         title: "arrow.uturn.backward.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["left", "undo"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1546,7 +1546,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUturnBackwardSquareFill = SFSymbol(
         title: "arrow.uturn.backward.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["left", "undo"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1568,7 +1568,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUturnForwardCircle = SFSymbol(
         title: "arrow.uturn.forward.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: ["redo", "right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1579,7 +1579,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUturnForwardCircleFill = SFSymbol(
         title: "arrow.uturn.forward.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["redo", "right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1590,7 +1590,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUturnForwardSquare = SFSymbol(
         title: "arrow.uturn.forward.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["redo", "right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1601,7 +1601,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUturnForwardSquareFill = SFSymbol(
         title: "arrow.uturn.forward.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["redo", "right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1678,7 +1678,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowshapeTurnUpBackward2Circle = SFSymbol(
         title: "arrowshape.turn.up.backward.2.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1711,7 +1711,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowshapeTurnUpBackwardCircle = SFSymbol(
         title: "arrowshape.turn.up.backward.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1755,7 +1755,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowshapeTurnUpForwardCircle = SFSymbol(
         title: "arrowshape.turn.up.forward.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1788,7 +1788,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowshapeTurnUpLeft2Circle = SFSymbol(
         title: "arrowshape.turn.up.left.2.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: ["reply all"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1865,7 +1865,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowtriangleBackwardCircle = SFSymbol(
         title: "arrowtriangle.backward.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1898,7 +1898,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowtriangleBackwardSquare = SFSymbol(
         title: "arrowtriangle.backward.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1931,7 +1931,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowtriangleForwardCircle = SFSymbol(
         title: "arrowtriangle.forward.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1964,7 +1964,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowtriangleForwardSquare = SFSymbol(
         title: "arrowtriangle.forward.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2034,7 +2034,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let atCircle = SFSymbol(
         title: "at.circle",
-        categories: [.multicolor, .variable],
+        categories: [.multicolor, .variable, .draw],
         searchTerms: ["@"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -2100,7 +2100,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let bagCircle = SFSymbol(
         title: "bag.circle",
-        categories: [.commerce, .objectsAndTools, .variable],
+        categories: [.commerce, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2192,7 +2192,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let bellSlashCircle = SFSymbol(
         title: "bell.slash.circle",
-        categories: [.multicolor, .objectsAndTools, .variable],
+        categories: [.multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -2225,7 +2225,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let bicycleCircle = SFSymbol(
         title: "bicycle.circle",
-        categories: [.maps, .transportation, .variable],
+        categories: [.maps, .transportation, .variable, .draw],
         searchTerms: ["bike"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2339,7 +2339,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let boltSlashCircle = SFSymbol(
         title: "bolt.slash.circle",
-        categories: [.cameraAndPhotos, .multicolor, .nature, .variable],
+        categories: [.cameraAndPhotos, .multicolor, .nature, .variable, .draw],
         searchTerms: ["camera", "energy", "power", "remove"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -2396,7 +2396,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let bookmarkCircle = SFSymbol(
         title: "bookmark.circle",
-        categories: [.multicolor, .objectsAndTools, .variable],
+        categories: [.multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: ["bookmark"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -2418,7 +2418,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let bookmarkSlash = SFSymbol(
         title: "bookmark.slash",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -2429,7 +2429,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let bookmarkSlashFill = SFSymbol(
         title: "bookmark.slash.fill",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -2809,7 +2809,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let carCircle = SFSymbol(
         title: "car.circle",
-        categories: [.automotive, .devices, .maps, .multicolor, .transportation, .variable],
+        categories: [.automotive, .devices, .maps, .multicolor, .transportation, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -2904,7 +2904,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
     static let checkmarkIcloud = SFSymbol(
         title: "checkmark.icloud",
-        categories: [.connectivity, .privacyAndSecurity],
+        categories: [.connectivity, .privacyAndSecurity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2917,7 +2917,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
     static let checkmarkIcloudFill = SFSymbol(
         title: "checkmark.icloud.fill",
-        categories: [.connectivity, .multicolor, .privacyAndSecurity],
+        categories: [.connectivity, .multicolor, .privacyAndSecurity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -2929,7 +2929,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let checkmarkRectanglePortrait = SFSymbol(
         title: "checkmark.rectangle.portrait",
-        categories: [.privacyAndSecurity],
+        categories: [.privacyAndSecurity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2940,7 +2940,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let checkmarkRectanglePortraitFill = SFSymbol(
         title: "checkmark.rectangle.portrait.fill",
-        categories: [.multicolor, .privacyAndSecurity],
+        categories: [.multicolor, .privacyAndSecurity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -2973,7 +2973,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chevronBackwardCircle = SFSymbol(
         title: "chevron.backward.circle",
-        categories: [.arrows, .cameraAndPhotos, .variable],
+        categories: [.arrows, .cameraAndPhotos, .variable, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2995,7 +2995,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chevronBackwardSquare = SFSymbol(
         title: "chevron.backward.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3039,7 +3039,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chevronForwardCircle = SFSymbol(
         title: "chevron.forward.circle",
-        categories: [.arrows, .cameraAndPhotos, .variable],
+        categories: [.arrows, .cameraAndPhotos, .variable, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3061,7 +3061,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chevronForwardSquare = SFSymbol(
         title: "chevron.forward.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3096,7 +3096,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let circleCircle = SFSymbol(
         title: "circle.circle",
-        categories: [.gaming, .variable],
+        categories: [.gaming, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3229,7 +3229,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let circleSquare = SFSymbol(
         title: "circle.square",
-        categories: [.gaming],
+        categories: [.gaming, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3384,7 +3384,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let commandCircle = SFSymbol(
         title: "command.circle",
-        categories: [.keyboard, .variable],
+        categories: [.keyboard, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3406,7 +3406,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let commandSquare = SFSymbol(
         title: "command.square",
-        categories: [.keyboard],
+        categories: [.keyboard, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3474,7 +3474,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let creditcardCircle = SFSymbol(
         title: "creditcard.circle",
-        categories: [.commerce, .objectsAndTools, .variable],
+        categories: [.commerce, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3529,7 +3529,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let crossCircle = SFSymbol(
         title: "cross.circle",
-        categories: [.health, .multicolor, .variable],
+        categories: [.health, .multicolor, .variable, .draw],
         searchTerms: ["medical"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -3619,7 +3619,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let curlybracesSquare = SFSymbol(
         title: "curlybraces.square",
-        categories: nil,
+        categories: [.draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4495,7 +4495,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let ejectCircle = SFSymbol(
         title: "eject.circle",
-        categories: [.keyboard, .variable],
+        categories: [.keyboard, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4903,7 +4903,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let eyeCircle = SFSymbol(
         title: "eye.circle",
-        categories: [.accessibility, .health, .human, .privacyAndSecurity, .variable],
+        categories: [.accessibility, .health, .human, .privacyAndSecurity, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5061,7 +5061,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureWalkCircle = SFSymbol(
         title: "figure.walk.circle",
-        categories: [.fitness, .human, .maps, .transportation, .variable],
+        categories: [.fitness, .human, .maps, .transportation, .variable, .draw],
         searchTerms: ["human", "indoor walk", "outdoor walk", "person", "sports", "walking"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5116,7 +5116,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureWaveCircle = SFSymbol(
         title: "figure.wave.circle",
-        categories: [.human, .maps, .transportation, .variable],
+        categories: [.human, .maps, .transportation, .variable, .draw],
         searchTerms: ["human", "person"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5186,7 +5186,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let flagSlashCircle = SFSymbol(
         title: "flag.slash.circle",
-        categories: [.multicolor, .objectsAndTools, .variable],
+        categories: [.multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -5348,7 +5348,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let giftCircle = SFSymbol(
         title: "gift.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["birthday"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5662,7 +5662,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let headphonesCircle = SFSymbol(
         title: "headphones.circle",
-        categories: [.devices, .objectsAndTools, .variable],
+        categories: [.devices, .objectsAndTools, .variable, .draw],
         searchTerms: ["audio", "sound", "speaker"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5708,7 +5708,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let heartTextSquareFill = SFSymbol(
         title: "heart.text.square.fill",
-        categories: [.health, .multicolor],
+        categories: [.health, .multicolor, .draw],
         searchTerms: ["medical"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -5854,7 +5854,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let houseCircle = SFSymbol(
         title: "house.circle",
-        categories: [.gaming, .home, .multicolor, .variable],
+        categories: [.gaming, .home, .multicolor, .variable, .draw],
         searchTerms: ["home", "house"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -6709,7 +6709,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let listBulletRectangle = SFSymbol(
         title: "list.bullet.rectangle",
-        categories: nil,
+        categories: [.draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6803,7 +6803,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let lockRectangle = SFSymbol(
         title: "lock.rectangle",
-        categories: [.multicolor, .objectsAndTools, .privacyAndSecurity],
+        categories: [.multicolor, .objectsAndTools, .privacyAndSecurity, .draw],
         searchTerms: ["padlock", "password", "security"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -6869,7 +6869,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let lockSquare = SFSymbol(
         title: "lock.square",
-        categories: [.multicolor, .objectsAndTools, .privacyAndSecurity],
+        categories: [.multicolor, .objectsAndTools, .privacyAndSecurity, .draw],
         searchTerms: ["padlock", "password", "security"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -7111,7 +7111,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, multicolor
     static let mailFill = SFSymbol(
         title: "mail.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["address", "letter", "mail"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .multicolor]
@@ -7243,7 +7243,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let minusDiamond = SFSymbol(
         title: "minus.diamond",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["-", "decrease", "delete", "remove", "subtract", "−"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -7254,7 +7254,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let minusDiamondFill = SFSymbol(
         title: "minus.diamond.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["-", "decrease", "delete", "remove", "subtract", "−"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -7287,7 +7287,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let minusRectanglePortrait = SFSymbol(
         title: "minus.rectangle.portrait",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["-", "remove"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -7298,7 +7298,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let minusRectanglePortraitFill = SFSymbol(
         title: "minus.rectangle.portrait.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["-", "remove"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -7689,7 +7689,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let paperplaneCircle = SFSymbol(
         title: "paperplane.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["send"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7748,7 +7748,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let person2Circle = SFSymbol(
         title: "person.2.circle",
-        categories: [.human, .variable],
+        categories: [.human, .variable, .draw],
         searchTerms: ["people", "shared"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8150,7 +8150,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let playSlash = SFSymbol(
         title: "play.slash",
-        categories: [.media],
+        categories: [.media, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8161,7 +8161,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let playSlashFill = SFSymbol(
         title: "play.slash.fill",
-        categories: [.media],
+        categories: [.media, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8172,7 +8172,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let plusDiamond = SFSymbol(
         title: "plus.diamond",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["+", "add", "create", "new"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -8183,7 +8183,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let plusDiamondFill = SFSymbol(
         title: "plus.diamond.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["+", "add", "create", "new"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -8208,7 +8208,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Messages app.
     static let plusMessageFill = SFSymbol(
         title: "plus.message.fill",
-        categories: [.communication, .multicolor],
+        categories: [.communication, .multicolor, .draw],
         searchTerms: ["add"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -8244,7 +8244,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let plusRectanglePortrait = SFSymbol(
         title: "plus.rectangle.portrait",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["+", "add"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -8255,7 +8255,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let plusRectanglePortraitFill = SFSymbol(
         title: "plus.rectangle.portrait.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["+", "add"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -8266,7 +8266,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let plusViewfinder = SFSymbol(
         title: "plus.viewfinder",
-        categories: [.cameraAndPhotos],
+        categories: [.cameraAndPhotos, .draw],
         searchTerms: ["add"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9196,7 +9196,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rectangleSlash = SFSymbol(
         title: "rectangle.slash",
-        categories: nil,
+        categories: [.draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9207,7 +9207,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rectangleSlashFill = SFSymbol(
         title: "rectangle.slash.fill",
-        categories: nil,
+        categories: [.draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9295,7 +9295,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let restartCircle = SFSymbol(
         title: "restart.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: ["restart"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9519,7 +9519,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let shekelsignCircle = SFSymbol(
         title: "shekelsign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9541,7 +9541,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let shekelsignSquare = SFSymbol(
         title: "shekelsign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9834,7 +9834,7 @@ public extension SFSymbol {
     /// - Localizations: Right-to-Left
     static let speakerSlashCircle = SFSymbol(
         title: "speaker.slash.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["remove", "volume"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -9870,7 +9870,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let speakerWave1Fill = SFSymbol(
         title: "speaker.wave.1.fill",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["volume"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9892,7 +9892,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let speakerWave2Circle = SFSymbol(
         title: "speaker.wave.2.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["volume"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9914,7 +9914,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let speakerWave2Fill = SFSymbol(
         title: "speaker.wave.2.fill",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["volume"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9936,7 +9936,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let speakerWave3Fill = SFSymbol(
         title: "speaker.wave.3.fill",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["volume"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10062,7 +10062,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let squareCircle = SFSymbol(
         title: "square.circle",
-        categories: [.gaming, .variable],
+        categories: [.gaming, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10352,7 +10352,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let squareSlash = SFSymbol(
         title: "square.slash",
-        categories: nil,
+        categories: [.draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10363,7 +10363,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let squareSlashFill = SFSymbol(
         title: "square.slash.fill",
-        categories: nil,
+        categories: [.draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10632,7 +10632,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let starSquare = SFSymbol(
         title: "star.square",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["favorite"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -10654,7 +10654,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let staroflifeCircle = SFSymbol(
         title: "staroflife.circle",
-        categories: [.health, .variable],
+        categories: [.health, .variable, .draw],
         searchTerms: ["medical"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10757,7 +10757,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tagSlash = SFSymbol(
         title: "tag.slash",
-        categories: [.objectsAndTools],
+        categories: [.objectsAndTools, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10768,7 +10768,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tagSlashFill = SFSymbol(
         title: "tag.slash.fill",
-        categories: [.objectsAndTools],
+        categories: [.objectsAndTools, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10791,7 +10791,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Teletype feature.
     static let teletypeCircle = SFSymbol(
         title: "teletype.circle",
-        categories: [.accessibility, .communication, .multicolor, .variable],
+        categories: [.accessibility, .communication, .multicolor, .variable, .draw],
         searchTerms: ["phone", "rtt"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -10867,7 +10867,7 @@ public extension SFSymbol {
     /// - Localizations: Right-to-Left
     static let textBelowPhotoFill = SFSymbol(
         title: "text.below.photo.fill",
-        categories: [.cameraAndPhotos],
+        categories: [.cameraAndPhotos, .draw],
         searchTerms: ["environment", "image", "mountain", "photograph", "picture", "place", "sun"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome],
@@ -10925,7 +10925,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let thermometerSunFill = SFSymbol(
         title: "thermometer.sun.fill",
-        categories: [.multicolor, .nature, .variable, .weather],
+        categories: [.multicolor, .nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -10969,7 +10969,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let timerSquare = SFSymbol(
         title: "timer.square",
-        categories: [.objectsAndTools, .time],
+        categories: [.objectsAndTools, .time, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11017,7 +11017,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tramCircle = SFSymbol(
         title: "tram.circle",
-        categories: [.maps, .transportation, .variable],
+        categories: [.maps, .transportation, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11052,7 +11052,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let trayCircle = SFSymbol(
         title: "tray.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["inbox", "mail"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11074,7 +11074,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let triangleCircle = SFSymbol(
         title: "triangle.circle",
-        categories: [.gaming, .variable],
+        categories: [.gaming, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11194,7 +11194,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, multicolor
     static let walletPassFill = SFSymbol(
         title: "wallet.pass.fill",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .multicolor]
@@ -11216,7 +11216,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let wave3BackwardCircle = SFSymbol(
         title: "wave.3.backward.circle",
-        categories: [.connectivity, .variable],
+        categories: [.connectivity, .variable, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11227,7 +11227,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let wave3BackwardCircleFill = SFSymbol(
         title: "wave.3.backward.circle.fill",
-        categories: [.connectivity, .multicolor, .variable],
+        categories: [.connectivity, .multicolor, .variable, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -11249,7 +11249,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let wave3ForwardCircle = SFSymbol(
         title: "wave.3.forward.circle",
-        categories: [.connectivity, .variable],
+        categories: [.connectivity, .variable, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11260,7 +11260,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let wave3ForwardCircleFill = SFSymbol(
         title: "wave.3.forward.circle.fill",
-        categories: [.connectivity, .multicolor, .variable],
+        categories: [.connectivity, .multicolor, .variable, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -11282,7 +11282,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let wave3LeftCircle = SFSymbol(
         title: "wave.3.left.circle",
-        categories: [.connectivity, .variable],
+        categories: [.connectivity, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11293,7 +11293,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let wave3LeftCircleFill = SFSymbol(
         title: "wave.3.left.circle.fill",
-        categories: [.connectivity, .multicolor, .variable],
+        categories: [.connectivity, .multicolor, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -11315,7 +11315,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let wave3RightCircle = SFSymbol(
         title: "wave.3.right.circle",
-        categories: [.connectivity, .variable],
+        categories: [.connectivity, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11326,7 +11326,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let wave3RightCircleFill = SFSymbol(
         title: "wave.3.right.circle.fill",
-        categories: [.connectivity, .multicolor, .variable],
+        categories: [.connectivity, .multicolor, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -11392,7 +11392,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let xmarkBinCircle = SFSymbol(
         title: "xmark.bin.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["junk", "mail", "spam"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -11414,7 +11414,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let xmarkBinFill = SFSymbol(
         title: "xmark.bin.fill",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: ["junk", "mail", "spam"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -11425,7 +11425,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let xmarkDiamond = SFSymbol(
         title: "xmark.diamond",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["*", "multiply", "times"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -11436,7 +11436,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let xmarkDiamondFill = SFSymbol(
         title: "xmark.diamond.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["*", "multiply", "times"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -11447,7 +11447,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let xmarkRectanglePortrait = SFSymbol(
         title: "xmark.rectangle.portrait",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["x"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -11458,7 +11458,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let xmarkRectanglePortraitFill = SFSymbol(
         title: "xmark.rectangle.portrait.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["x"],
         releaseInfo: ReleaseInfo(iOS: 14.0, macOS: 11.0, tvOS: 14.0, watchOS: 7.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables14P2.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables14P2.swift
@@ -46,7 +46,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let brazilianrealsignCircle = SFSymbol(
         title: "brazilianrealsign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 14.2, macOS: 11.0, tvOS: 14.2, watchOS: 7.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -68,7 +68,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let brazilianrealsignSquare = SFSymbol(
         title: "brazilianrealsign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 14.2, macOS: 11.0, tvOS: 14.2, watchOS: 7.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -90,7 +90,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cartCircle = SFSymbol(
         title: "cart.circle",
-        categories: [.commerce, .objectsAndTools, .variable],
+        categories: [.commerce, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.2, macOS: 11.0, tvOS: 14.2, watchOS: 7.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -190,7 +190,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let infinityCircle = SFSymbol(
         title: "infinity.circle",
-        categories: [.media, .variable],
+        categories: [.media, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 14.2, macOS: 11.0, tvOS: 14.2, watchOS: 7.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -411,7 +411,7 @@ public extension SFSymbol {
     /// - Localizations: Arabic, Hindi
     static let repeat1Circle = SFSymbol(
         title: "repeat.1.circle",
-        categories: [.arrows, .media, .variable],
+        categories: [.arrows, .media, .variable, .draw],
         searchTerms: ["arrow", "arrow.trianglehead", "trianglehead"],
         releaseInfo: ReleaseInfo(iOS: 14.2, macOS: 11.0, tvOS: 14.2, watchOS: 7.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -436,7 +436,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let repeatCircle = SFSymbol(
         title: "repeat.circle",
-        categories: [.arrows, .media, .variable],
+        categories: [.arrows, .media, .variable, .draw],
         searchTerms: ["arrow", "arrow.trianglehead", "trianglehead"],
         releaseInfo: ReleaseInfo(iOS: 14.2, macOS: 11.0, tvOS: 14.2, watchOS: 7.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -447,7 +447,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let repeatCircleFill = SFSymbol(
         title: "repeat.circle.fill",
-        categories: [.arrows, .media, .multicolor],
+        categories: [.arrows, .media, .multicolor, .draw],
         searchTerms: ["arrow", "arrow.trianglehead", "trianglehead"],
         releaseInfo: ReleaseInfo(iOS: 14.2, macOS: 11.0, tvOS: 14.2, watchOS: 7.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -471,7 +471,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let shuffleCircle = SFSymbol(
         title: "shuffle.circle",
-        categories: [.arrows, .media, .variable],
+        categories: [.arrows, .media, .variable, .draw],
         searchTerms: ["arrow", "arrow.trianglehead", "trianglehead"],
         releaseInfo: ReleaseInfo(iOS: 14.2, macOS: 11.0, tvOS: 14.2, watchOS: 7.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -482,7 +482,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let shuffleCircleFill = SFSymbol(
         title: "shuffle.circle.fill",
-        categories: [.arrows, .media, .multicolor],
+        categories: [.arrows, .media, .multicolor, .draw],
         searchTerms: ["arrow", "arrow.trianglehead", "trianglehead"],
         releaseInfo: ReleaseInfo(iOS: 14.2, macOS: 11.0, tvOS: 14.2, watchOS: 7.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables15.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables15.swift
@@ -264,7 +264,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s AirTag.
     static let airtagRadiowavesForwardFill = SFSymbol(
         title: "airtag.radiowaves.forward.fill",
-        categories: [.devices, .variable],
+        categories: [.devices, .variable, .draw],
         searchTerms: ["findable", "location"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -310,7 +310,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let alignHorizontalLeftFill = SFSymbol(
         title: "align.horizontal.left.fill",
-        categories: [.editing],
+        categories: [.editing, .draw],
         searchTerms: ["rectangle", "shape"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -332,7 +332,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let alignHorizontalRightFill = SFSymbol(
         title: "align.horizontal.right.fill",
-        categories: [.editing],
+        categories: [.editing, .draw],
         searchTerms: ["rectangle", "shape"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -354,7 +354,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let alignVerticalBottomFill = SFSymbol(
         title: "align.vertical.bottom.fill",
-        categories: [.editing],
+        categories: [.editing, .draw],
         searchTerms: ["rectangle", "shape"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -398,7 +398,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let alignVerticalTopFill = SFSymbol(
         title: "align.vertical.top.fill",
-        categories: [.editing],
+        categories: [.editing, .draw],
         searchTerms: ["rectangle", "shape"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -431,7 +431,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let antennaRadiowavesLeftAndRightCircle = SFSymbol(
         title: "antenna.radiowaves.left.and.right.circle",
-        categories: [.connectivity, .multicolor, .objectsAndTools, .variable],
+        categories: [.connectivity, .multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: ["cellular", "lte"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -442,7 +442,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let antennaRadiowavesLeftAndRightCircleFill = SFSymbol(
         title: "antenna.radiowaves.left.and.right.circle.fill",
-        categories: [.connectivity, .multicolor, .objectsAndTools, .variable],
+        categories: [.connectivity, .multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: ["cellular", "lte"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -453,7 +453,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let antennaRadiowavesLeftAndRightSlash = SFSymbol(
         title: "antenna.radiowaves.left.and.right.slash",
-        categories: [.connectivity, .multicolor, .objectsAndTools],
+        categories: [.connectivity, .multicolor, .objectsAndTools, .draw],
         searchTerms: ["cellular", "lte", "remove"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -662,7 +662,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowBackwardToLineCircle = SFSymbol(
         title: "arrow.backward.to.line.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -684,7 +684,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownToLineCircle = SFSymbol(
         title: "arrow.down.to.line.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -728,7 +728,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowForwardToLineCircle = SFSymbol(
         title: "arrow.forward.to.line.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -750,7 +750,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowLeftToLineCircle = SFSymbol(
         title: "arrow.left.to.line.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -783,7 +783,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowRightToLineCircle = SFSymbol(
         title: "arrow.right.to.line.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -829,7 +829,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpToLineCircle = SFSymbol(
         title: "arrow.up.to.line.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -862,7 +862,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome
     static let arrowtriangleLeftAndLineVerticalAndArrowtriangleRightFill = SFSymbol(
         title: "arrowtriangle.left.and.line.vertical.and.arrowtriangle.right.fill",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome]
@@ -873,7 +873,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome
     static let arrowtriangleRightAndLineVerticalAndArrowtriangleLeftFill = SFSymbol(
         title: "arrowtriangle.right.and.line.vertical.and.arrowtriangle.left.fill",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome]
@@ -895,7 +895,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let backwardCircle = SFSymbol(
         title: "backward.circle",
-        categories: [.media, .variable],
+        categories: [.media, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1125,7 +1125,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let bedDoubleCircle = SFSymbol(
         title: "bed.double.circle",
-        categories: [.health, .home, .multicolor, .objectsAndTools, .variable],
+        categories: [.health, .home, .multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: ["medical", "sleep"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1173,7 +1173,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let bellBadgeCircle = SFSymbol(
         title: "bell.badge.circle",
-        categories: [.multicolor, .objectsAndTools, .variable],
+        categories: [.multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1195,7 +1195,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let bellSquare = SFSymbol(
         title: "bell.square",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: ["notify"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1239,7 +1239,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let boltCarCircle = SFSymbol(
         title: "bolt.car.circle",
-        categories: [.automotive, .devices, .multicolor, .transportation, .variable],
+        categories: [.automotive, .devices, .multicolor, .transportation, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1283,7 +1283,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let boltSquare = SFSymbol(
         title: "bolt.square",
-        categories: [.cameraAndPhotos, .multicolor, .nature],
+        categories: [.cameraAndPhotos, .multicolor, .nature, .draw],
         searchTerms: ["camera", "energy", "power"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1305,7 +1305,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let bookClosedCircle = SFSymbol(
         title: "book.closed.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1327,7 +1327,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let bookmarkSquare = SFSymbol(
         title: "bookmark.square",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1349,7 +1349,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let booksVerticalCircle = SFSymbol(
         title: "books.vertical.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1393,7 +1393,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let briefcaseCircle = SFSymbol(
         title: "briefcase.circle",
-        categories: [.multicolor, .objectsAndTools, .variable],
+        categories: [.multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1437,7 +1437,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let bubbleLeftCircle = SFSymbol(
         title: "bubble.left.circle",
-        categories: [.communication, .variable],
+        categories: [.communication, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1459,7 +1459,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let bubbleRightCircle = SFSymbol(
         title: "bubble.right.circle",
-        categories: [.communication, .variable],
+        categories: [.communication, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1760,7 +1760,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chartLineUptrendXyaxisCircle = SFSymbol(
         title: "chart.line.uptrend.xyaxis.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1820,7 +1820,7 @@ public extension SFSymbol {
     /// - Localizations: Right-to-Left
     static let checkmarkBubble = SFSymbol(
         title: "checkmark.bubble",
-        categories: [.communication],
+        categories: [.communication, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -1833,7 +1833,7 @@ public extension SFSymbol {
     /// - Localizations: Right-to-Left
     static let checkmarkBubbleFill = SFSymbol(
         title: "checkmark.bubble.fill",
-        categories: [.communication],
+        categories: [.communication, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -1856,7 +1856,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let checkmarkDiamond = SFSymbol(
         title: "checkmark.diamond",
-        categories: [.multicolor, .privacyAndSecurity],
+        categories: [.multicolor, .privacyAndSecurity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1867,7 +1867,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let checkmarkDiamondFill = SFSymbol(
         title: "checkmark.diamond.fill",
-        categories: [.multicolor, .privacyAndSecurity],
+        categories: [.multicolor, .privacyAndSecurity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1992,7 +1992,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let circleGrid3x3Circle = SFSymbol(
         title: "circle.grid.3x3.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2069,7 +2069,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let circleHexagongridCircle = SFSymbol(
         title: "circle.hexagongrid.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2163,7 +2163,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let circleSlash = SFSymbol(
         title: "circle.slash",
-        categories: nil,
+        categories: [.draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2174,7 +2174,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let circleSlashFill = SFSymbol(
         title: "circle.slash.fill",
-        categories: nil,
+        categories: [.draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2253,7 +2253,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let clockCircle = SFSymbol(
         title: "clock.circle",
-        categories: [.objectsAndTools, .time, .variable],
+        categories: [.objectsAndTools, .time, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2455,7 +2455,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let diamondCircle = SFSymbol(
         title: "diamond.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2565,7 +2565,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Digital Crown.
     static let digitalcrownArrowClockwiseFill = SFSymbol(
         title: "digitalcrown.arrow.clockwise.fill",
-        categories: [.accessibility, .devices],
+        categories: [.accessibility, .devices, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2591,7 +2591,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Digital Crown.
     static let digitalcrownArrowCounterclockwiseFill = SFSymbol(
         title: "digitalcrown.arrow.counterclockwise.fill",
-        categories: [.accessibility, .devices],
+        categories: [.accessibility, .devices, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2617,7 +2617,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Digital Crown.
     static let digitalcrownHorizontalArrowClockwiseFill = SFSymbol(
         title: "digitalcrown.horizontal.arrow.clockwise.fill",
-        categories: [.devices],
+        categories: [.devices, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2643,7 +2643,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Digital Crown.
     static let digitalcrownHorizontalArrowCounterclockwiseFill = SFSymbol(
         title: "digitalcrown.horizontal.arrow.counterclockwise.fill",
-        categories: [.devices],
+        categories: [.devices, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2669,7 +2669,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Digital Crown.
     static let digitalcrownHorizontalPressFill = SFSymbol(
         title: "digitalcrown.horizontal.press.fill",
-        categories: [.devices],
+        categories: [.devices, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2695,7 +2695,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Digital Crown.
     static let digitalcrownPressFill = SFSymbol(
         title: "digitalcrown.press.fill",
-        categories: [.accessibility, .devices],
+        categories: [.accessibility, .devices, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2858,7 +2858,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let dropCircle = SFSymbol(
         title: "drop.circle",
-        categories: [.nature, .variable],
+        categories: [.nature, .variable, .draw],
         searchTerms: ["blood", "oil", "water"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2981,7 +2981,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let exclamationmarkBubbleCircle = SFSymbol(
         title: "exclamationmark.bubble.circle",
-        categories: [.communication, .maps, .privacyAndSecurity, .variable],
+        categories: [.communication, .maps, .privacyAndSecurity, .variable, .draw],
         searchTerms: ["!", "warning"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3003,7 +3003,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let eyeSlashCircle = SFSymbol(
         title: "eye.slash.circle",
-        categories: [.accessibility, .human, .privacyAndSecurity, .variable],
+        categories: [.accessibility, .human, .privacyAndSecurity, .variable, .draw],
         searchTerms: ["hidden", "remove"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3025,7 +3025,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let eyeSquare = SFSymbol(
         title: "eye.square",
-        categories: [.accessibility, .health, .human, .privacyAndSecurity],
+        categories: [.accessibility, .health, .human, .privacyAndSecurity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3161,7 +3161,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let filmCircle = SFSymbol(
         title: "film.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3227,7 +3227,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let flagSquare = SFSymbol(
         title: "flag.square",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -3249,7 +3249,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let flameCircle = SFSymbol(
         title: "flame.circle",
-        categories: [.nature, .variable],
+        categories: [.nature, .variable, .draw],
         searchTerms: ["fire"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3304,7 +3304,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let forkKnifeCircle = SFSymbol(
         title: "fork.knife.circle",
-        categories: [.multicolor, .objectsAndTools, .variable],
+        categories: [.multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: ["drink", "food"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -3326,7 +3326,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let forwardCircle = SFSymbol(
         title: "forward.circle",
-        categories: [.media, .variable],
+        categories: [.media, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3359,7 +3359,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let fuelpumpCircle = SFSymbol(
         title: "fuelpump.circle",
-        categories: [.automotive, .maps, .objectsAndTools, .transportation, .variable],
+        categories: [.automotive, .maps, .objectsAndTools, .transportation, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3425,7 +3425,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let gearCircle = SFSymbol(
         title: "gear.circle",
-        categories: [.multicolor, .variable],
+        categories: [.multicolor, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -3447,7 +3447,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let gearshapeCircle = SFSymbol(
         title: "gearshape.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3576,7 +3576,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let graduationcapCircle = SFSymbol(
         title: "graduationcap.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["college", "education", "hat", "school", "student"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3609,7 +3609,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let hammerCircle = SFSymbol(
         title: "hammer.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3631,7 +3631,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let handRaisedCircle = SFSymbol(
         title: "hand.raised.circle",
-        categories: [.human, .multicolor, .privacyAndSecurity, .variable],
+        categories: [.human, .multicolor, .privacyAndSecurity, .variable, .draw],
         searchTerms: ["privacy"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -3653,7 +3653,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let handRaisedSquare = SFSymbol(
         title: "hand.raised.square",
-        categories: [.human, .multicolor, .privacyAndSecurity],
+        categories: [.human, .multicolor, .privacyAndSecurity, .draw],
         searchTerms: ["privacy"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -3697,7 +3697,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let handThumbsdownCircle = SFSymbol(
         title: "hand.thumbsdown.circle",
-        categories: [.human, .variable],
+        categories: [.human, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3719,7 +3719,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let handThumbsupCircle = SFSymbol(
         title: "hand.thumbsup.circle",
-        categories: [.human, .variable],
+        categories: [.human, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3752,7 +3752,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let heartRectangle = SFSymbol(
         title: "heart.rectangle",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["medical"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -3774,7 +3774,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let heartSquare = SFSymbol(
         title: "heart.square",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["medical"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -3941,7 +3941,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let hourglassCircle = SFSymbol(
         title: "hourglass.circle",
-        categories: [.multicolor, .objectsAndTools, .time, .variable],
+        categories: [.multicolor, .objectsAndTools, .time, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -3985,7 +3985,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let humidityFill = SFSymbol(
         title: "humidity.fill",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["drop", "weather"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3997,7 +3997,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
     static let icloudSquare = SFSymbol(
         title: "icloud.square",
-        categories: [.connectivity, .multicolor],
+        categories: [.connectivity, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -4071,7 +4071,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iPhone.
     static let iphoneCircle = SFSymbol(
         title: "iphone.circle",
-        categories: [.devices, .variable],
+        categories: [.devices, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -4175,7 +4175,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iPhone.
     static let iphoneRadiowavesLeftAndRightCircle = SFSymbol(
         title: "iphone.radiowaves.left.and.right.circle",
-        categories: [.devices, .variable],
+        categories: [.devices, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -4212,7 +4212,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iPhone.
     static let iphoneSlashCircle = SFSymbol(
         title: "iphone.slash.circle",
-        categories: [.devices, .variable],
+        categories: [.devices, .variable, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -4487,7 +4487,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let leafCircle = SFSymbol(
         title: "leaf.circle",
-        categories: [.multicolor, .nature, .variable],
+        categories: [.multicolor, .nature, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4509,7 +4509,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let lightbulbCircle = SFSymbol(
         title: "lightbulb.circle",
-        categories: [.home, .objectsAndTools, .variable],
+        categories: [.home, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4542,7 +4542,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let line2HorizontalDecreaseCircleFill = SFSymbol(
         title: "line.2.horizontal.decrease.circle.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4564,7 +4564,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let line3HorizontalCircle = SFSymbol(
         title: "line.3.horizontal.circle",
-        categories: [.gaming, .variable],
+        categories: [.gaming, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4575,7 +4575,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let line3HorizontalCircleFill = SFSymbol(
         title: "line.3.horizontal.circle.fill",
-        categories: [.gaming, .multicolor],
+        categories: [.gaming, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4597,7 +4597,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let line3HorizontalDecreaseCircle = SFSymbol(
         title: "line.3.horizontal.decrease.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: ["filter", "mail"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4608,7 +4608,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let line3HorizontalDecreaseCircleFill = SFSymbol(
         title: "line.3.horizontal.decrease.circle.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["filter", "mail"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4630,7 +4630,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let listBulletCircle = SFSymbol(
         title: "list.bullet.circle",
-        categories: [.textFormatting, .variable],
+        categories: [.textFormatting, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4652,7 +4652,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let listBulletRectangleFill = SFSymbol(
         title: "list.bullet.rectangle.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4663,7 +4663,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let listBulletRectanglePortrait = SFSymbol(
         title: "list.bullet.rectangle.portrait",
-        categories: nil,
+        categories: [.draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4674,7 +4674,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let listBulletRectanglePortraitFill = SFSymbol(
         title: "list.bullet.rectangle.portrait.fill",
-        categories: nil,
+        categories: [.draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4707,7 +4707,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let locationNorthCircle = SFSymbol(
         title: "location.north.circle",
-        categories: [.arrows, .maps, .multicolor, .variable],
+        categories: [.arrows, .maps, .multicolor, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4729,7 +4729,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let locationSquare = SFSymbol(
         title: "location.square",
-        categories: [.arrows, .maps, .multicolor],
+        categories: [.arrows, .maps, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -5000,7 +5000,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let mapCircle = SFSymbol(
         title: "map.circle",
-        categories: [.maps, .objectsAndTools, .variable],
+        categories: [.maps, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5022,7 +5022,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let mappinSlashCircle = SFSymbol(
         title: "mappin.slash.circle",
-        categories: [.maps, .multicolor, .objectsAndTools, .variable],
+        categories: [.maps, .multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -5044,7 +5044,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let mappinSquare = SFSymbol(
         title: "mappin.square",
-        categories: [.maps, .multicolor, .objectsAndTools],
+        categories: [.maps, .multicolor, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -5284,7 +5284,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let newspaperCircle = SFSymbol(
         title: "newspaper.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5486,7 +5486,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let parkingsignCircle = SFSymbol(
         title: "parkingsign.circle",
-        categories: [.automotive, .variable],
+        categories: [.automotive, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5519,7 +5519,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pawprintCircle = SFSymbol(
         title: "pawprint.circle",
-        categories: [.nature, .variable],
+        categories: [.nature, .variable, .draw],
         searchTerms: ["animals", "pet friendly"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5664,7 +5664,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let person2Wave2Fill = SFSymbol(
         title: "person.2.wave.2.fill",
-        categories: [.human, .variable],
+        categories: [.human, .variable, .draw],
         searchTerms: ["people"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5897,7 +5897,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let personWave2Fill = SFSymbol(
         title: "person.wave.2.fill",
-        categories: [.human, .variable],
+        categories: [.human, .variable, .draw],
         searchTerms: ["people"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5908,7 +5908,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let personalhotspotCircle = SFSymbol(
         title: "personalhotspot.circle",
-        categories: [.connectivity, .objectsAndTools, .variable],
+        categories: [.connectivity, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5967,7 +5967,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let photoCircle = SFSymbol(
         title: "photo.circle",
-        categories: [.cameraAndPhotos, .variable],
+        categories: [.cameraAndPhotos, .variable, .draw],
         searchTerms: ["environment", "image", "mountain", "photograph", "picture", "place", "sun"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5989,7 +5989,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pillsCircle = SFSymbol(
         title: "pills.circle",
-        categories: [.health, .objectsAndTools, .variable],
+        categories: [.health, .objectsAndTools, .variable, .draw],
         searchTerms: ["medical"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6011,7 +6011,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let pinSquare = SFSymbol(
         title: "pin.square",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -6140,7 +6140,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let playRectangleOnRectangleCircle = SFSymbol(
         title: "play.rectangle.on.rectangle.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6173,7 +6173,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let playSquare = SFSymbol(
         title: "play.square",
-        categories: [.media],
+        categories: [.media, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6289,7 +6289,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let powerCircle = SFSymbol(
         title: "power.circle",
-        categories: [.keyboard, .variable],
+        categories: [.keyboard, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6300,7 +6300,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let powerCircleFill = SFSymbol(
         title: "power.circle.fill",
-        categories: [.keyboard, .multicolor],
+        categories: [.keyboard, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -6968,7 +6968,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rectangleOnRectangleCircle = SFSymbol(
         title: "rectangle.on.rectangle.circle",
-        categories: [.gaming, .variable],
+        categories: [.gaming, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6990,7 +6990,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rectangleOnRectangleSlashCircle = SFSymbol(
         title: "rectangle.on.rectangle.slash.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7023,7 +7023,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rectangleOnRectangleSquare = SFSymbol(
         title: "rectangle.on.rectangle.square",
-        categories: [.gaming],
+        categories: [.gaming, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7326,7 +7326,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rectanglePortraitSlash = SFSymbol(
         title: "rectangle.portrait.slash",
-        categories: nil,
+        categories: [.draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7337,7 +7337,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rectanglePortraitSlashFill = SFSymbol(
         title: "rectangle.portrait.slash.fill",
-        categories: nil,
+        categories: [.draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7370,7 +7370,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rectanglePortraitSplit2x1Slash = SFSymbol(
         title: "rectangle.portrait.split.2x1.slash",
-        categories: nil,
+        categories: [.draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7381,7 +7381,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rectanglePortraitSplit2x1SlashFill = SFSymbol(
         title: "rectangle.portrait.split.2x1.slash.fill",
-        categories: nil,
+        categories: [.draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7557,7 +7557,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rectangleSplit2x1Slash = SFSymbol(
         title: "rectangle.split.2x1.slash",
-        categories: nil,
+        categories: [.draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7568,7 +7568,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rectangleSplit2x1SlashFill = SFSymbol(
         title: "rectangle.split.2x1.slash.fill",
-        categories: nil,
+        categories: [.draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7721,7 +7721,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let scissorsCircle = SFSymbol(
         title: "scissors.circle",
-        categories: [.editing, .objectsAndTools, .variable],
+        categories: [.editing, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7787,7 +7787,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sensorTagRadiowavesForwardFill = SFSymbol(
         title: "sensor.tag.radiowaves.forward.fill",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["findable", "location"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7835,7 +7835,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let shieldLefthalfFilledSlash = SFSymbol(
         title: "shield.lefthalf.filled.slash",
-        categories: [.objectsAndTools, .privacyAndSecurity],
+        categories: [.objectsAndTools, .privacyAndSecurity, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7857,7 +7857,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let shippingboxCircle = SFSymbol(
         title: "shippingbox.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7879,7 +7879,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sleepCircle = SFSymbol(
         title: "sleep.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7962,7 +7962,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let snowflakeCircle = SFSymbol(
         title: "snowflake.circle",
-        categories: [.automotive, .nature, .variable, .weather],
+        categories: [.automotive, .nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8050,7 +8050,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let speakerCircle = SFSymbol(
         title: "speaker.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["volume"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8137,7 +8137,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let squareAndArrowUpCircle = SFSymbol(
         title: "square.and.arrow.up.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: ["export", "share", "sharrow", "upload"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8328,7 +8328,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let squareGrid3x3Square = SFSymbol(
         title: "square.grid.3x3.square",
-        categories: nil,
+        categories: [.draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8422,7 +8422,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let squareTextSquareFill = SFSymbol(
         title: "square.text.square.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -8479,7 +8479,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let stethoscopeCircle = SFSymbol(
         title: "stethoscope.circle",
-        categories: [.health, .objectsAndTools, .variable],
+        categories: [.health, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8571,7 +8571,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sunMaxCircle = SFSymbol(
         title: "sun.max.circle",
-        categories: [.keyboard, .nature, .variable, .weather],
+        categories: [.keyboard, .nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8604,7 +8604,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tagSquare = SFSymbol(
         title: "tag.square",
-        categories: [.objectsAndTools],
+        categories: [.objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8649,7 +8649,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Teletype feature.
     static let teletypeAnswerCircle = SFSymbol(
         title: "teletype.answer.circle",
-        categories: [.accessibility, .communication, .multicolor, .variable],
+        categories: [.accessibility, .communication, .multicolor, .variable, .draw],
         searchTerms: ["phone", "rtt"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -8707,7 +8707,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let theatermasksCircle = SFSymbol(
         title: "theatermasks.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8828,7 +8828,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let trashSlashCircle = SFSymbol(
         title: "trash.slash.circle",
-        categories: [.multicolor, .objectsAndTools, .variable],
+        categories: [.multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -8850,7 +8850,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let trashSlashSquare = SFSymbol(
         title: "trash.slash.square",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -8872,7 +8872,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let trashSquare = SFSymbol(
         title: "trash.square",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -9043,7 +9043,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
     static let videoSquare = SFSymbol(
         title: "video.square",
-        categories: [.communication, .multicolor],
+        categories: [.communication, .multicolor, .draw],
         searchTerms: ["facetime"],
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -9068,7 +9068,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let wakeCircle = SFSymbol(
         title: "wake.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9162,7 +9162,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let wifiCircle = SFSymbol(
         title: "wifi.circle",
-        categories: [.connectivity, .multicolor, .variable],
+        categories: [.connectivity, .multicolor, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -9184,7 +9184,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let wifiSquare = SFSymbol(
         title: "wifi.square",
-        categories: [.connectivity, .multicolor, .variable],
+        categories: [.connectivity, .multicolor, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -9206,7 +9206,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let xmarkApp = SFSymbol(
         title: "xmark.app",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -9217,7 +9217,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let xmarkAppFill = SFSymbol(
         title: "xmark.app.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 15.0, macOS: 12.0, tvOS: 15.0, watchOS: 8.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables15P4.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables15P4.swift
@@ -24,7 +24,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cameraMacroCircle = SFSymbol(
         title: "camera.macro.circle",
-        categories: [.cameraAndPhotos, .nature, .variable],
+        categories: [.cameraAndPhotos, .nature, .variable, .draw],
         searchTerms: ["macro"],
         releaseInfo: ReleaseInfo(iOS: 15.4, macOS: 12.3, tvOS: 15.4, watchOS: 8.5, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables16.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables16.swift
@@ -101,7 +101,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let alarmWavesLeftAndRightFill = SFSymbol(
         title: "alarm.waves.left.and.right.fill",
-        categories: [.objectsAndTools, .time, .variable],
+        categories: [.objectsAndTools, .time, .variable, .draw],
         searchTerms: ["alarm"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -172,7 +172,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Messages app.
     static let arrowDownMessageFill = SFSymbol(
         title: "arrow.down.message.fill",
-        categories: [.communication, .multicolor],
+        categories: [.communication, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -430,7 +430,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let backwardEndCircle = SFSymbol(
         title: "backward.end.circle",
-        categories: [.media, .variable],
+        categories: [.media, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -544,7 +544,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let baseballCircle = SFSymbol(
         title: "baseball.circle",
-        categories: [.fitness, .objectsAndTools, .variable],
+        categories: [.fitness, .objectsAndTools, .variable, .draw],
         searchTerms: ["sports"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -621,7 +621,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let basketballCircle = SFSymbol(
         title: "basketball.circle",
-        categories: [.fitness, .objectsAndTools, .variable],
+        categories: [.fitness, .objectsAndTools, .variable, .draw],
         searchTerms: ["sports"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -735,7 +735,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let bellAndWavesLeftAndRightFill = SFSymbol(
         title: "bell.and.waves.left.and.right.fill",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1000,7 +1000,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let buttonProgrammableSquare = SFSymbol(
         title: "button.programmable.square",
-        categories: [.home],
+        categories: [.home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1285,7 +1285,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chartLineDowntrendXyaxisCircle = SFSymbol(
         title: "chart.line.downtrend.xyaxis.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1318,7 +1318,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chartLineFlattrendXyaxisCircle = SFSymbol(
         title: "chart.line.flattrend.xyaxis.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1426,7 +1426,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Messages app.
     static let checkmarkMessageFill = SFSymbol(
         title: "checkmark.message.fill",
-        categories: [.communication, .multicolor, .privacyAndSecurity],
+        categories: [.communication, .multicolor, .privacyAndSecurity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -1482,7 +1482,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let circleDashedRectangle = SFSymbol(
         title: "circle.dashed.rectangle",
-        categories: [.cameraAndPhotos],
+        categories: [.cameraAndPhotos, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1618,7 +1618,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cloudBoltCircle = SFSymbol(
         title: "cloud.bolt.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1640,7 +1640,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cloudBoltRainCircle = SFSymbol(
         title: "cloud.bolt.rain.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1662,7 +1662,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cloudCircle = SFSymbol(
         title: "cloud.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1684,7 +1684,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cloudDrizzleCircle = SFSymbol(
         title: "cloud.drizzle.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1706,7 +1706,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cloudFogCircle = SFSymbol(
         title: "cloud.fog.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1728,7 +1728,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cloudHailCircle = SFSymbol(
         title: "cloud.hail.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1750,7 +1750,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cloudHeavyrainCircle = SFSymbol(
         title: "cloud.heavyrain.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1772,7 +1772,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cloudMoonBoltCircle = SFSymbol(
         title: "cloud.moon.bolt.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1794,7 +1794,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cloudMoonCircle = SFSymbol(
         title: "cloud.moon.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1816,7 +1816,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cloudMoonRainCircle = SFSymbol(
         title: "cloud.moon.rain.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1838,7 +1838,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cloudRainCircle = SFSymbol(
         title: "cloud.rain.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1860,7 +1860,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cloudSleetCircle = SFSymbol(
         title: "cloud.sleet.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1882,7 +1882,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cloudSnowCircle = SFSymbol(
         title: "cloud.snow.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1904,7 +1904,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cloudSunBoltCircle = SFSymbol(
         title: "cloud.sun.bolt.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1926,7 +1926,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cloudSunCircle = SFSymbol(
         title: "cloud.sun.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1948,7 +1948,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cloudSunRainCircle = SFSymbol(
         title: "cloud.sun.rain.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2058,7 +2058,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cricketBallCircle = SFSymbol(
         title: "cricket.ball.circle",
-        categories: [.fitness, .objectsAndTools, .variable],
+        categories: [.fitness, .objectsAndTools, .variable, .draw],
         searchTerms: ["sports"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2173,7 +2173,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Desk View.
     static let deskviewFill = SFSymbol(
         title: "deskview.fill",
-        categories: [.communication],
+        categories: [.communication, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2306,7 +2306,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let distributeHorizontalLeftFill = SFSymbol(
         title: "distribute.horizontal.left.fill",
-        categories: [.editing],
+        categories: [.editing, .draw],
         searchTerms: ["rectangle", "shape"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2328,7 +2328,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let distributeHorizontalRightFill = SFSymbol(
         title: "distribute.horizontal.right.fill",
-        categories: [.editing],
+        categories: [.editing, .draw],
         searchTerms: ["rectangle", "shape"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2350,7 +2350,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let distributeVerticalBottomFill = SFSymbol(
         title: "distribute.vertical.bottom.fill",
-        categories: [.editing],
+        categories: [.editing, .draw],
         searchTerms: ["rectangle", "shape"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2394,7 +2394,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let distributeVerticalTopFill = SFSymbol(
         title: "distribute.vertical.top.fill",
-        categories: [.editing],
+        categories: [.editing, .draw],
         searchTerms: ["rectangle", "shape"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2687,7 +2687,7 @@ public extension SFSymbol {
     /// - Localizations: Right-to-Left
     static let dropDegreesignSlash = SFSymbol(
         title: "drop.degreesign.slash",
-        categories: [.nature],
+        categories: [.nature, .draw],
         searchTerms: ["blood", "oil", "water"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2700,7 +2700,7 @@ public extension SFSymbol {
     /// - Localizations: Right-to-Left
     static let dropDegreesignSlashFill = SFSymbol(
         title: "drop.degreesign.slash.fill",
-        categories: [.nature],
+        categories: [.nature, .draw],
         searchTerms: ["blood", "oil", "water"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -3140,7 +3140,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let fanOscillationFill = SFSymbol(
         title: "fan.oscillation.fill",
-        categories: [.home, .objectsAndTools],
+        categories: [.home, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3465,7 +3465,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureFallCircle = SFSymbol(
         title: "figure.fall.circle",
-        categories: [.human, .variable],
+        categories: [.human, .variable, .draw],
         searchTerms: ["human", "person"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3819,7 +3819,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureRunCircle = SFSymbol(
         title: "figure.run.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "outdoor run", "person", "running", "sports"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4230,7 +4230,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let flag2CrossedCircle = SFSymbol(
         title: "flag.2.crossed.circle",
-        categories: [.fitness, .gaming, .objectsAndTools, .variable],
+        categories: [.fitness, .gaming, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4376,7 +4376,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let forwardEndCircle = SFSymbol(
         title: "forward.end.circle",
-        categories: [.media, .variable],
+        categories: [.media, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4779,7 +4779,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let hockeyPuckCircle = SFSymbol(
         title: "hockey.puck.circle",
-        categories: [.fitness, .objectsAndTools, .variable],
+        categories: [.fitness, .objectsAndTools, .variable, .draw],
         searchTerms: ["sports"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4878,7 +4878,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let hurricaneCircle = SFSymbol(
         title: "hurricane.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4937,7 +4937,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let infoSquare = SFSymbol(
         title: "info.square",
-        categories: [.automotive, .multicolor],
+        categories: [.automotive, .multicolor, .draw],
         searchTerms: ["info"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -5203,7 +5203,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let lightBeaconMaxFill = SFSymbol(
         title: "light.beacon.max.fill",
-        categories: [.home, .multicolor, .objectsAndTools],
+        categories: [.home, .multicolor, .objectsAndTools, .draw],
         searchTerms: ["emergency", "security alarm", "siren"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -5489,7 +5489,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let lightswitchOffSquare = SFSymbol(
         title: "lightswitch.off.square",
-        categories: [.home],
+        categories: [.home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5533,7 +5533,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let lightswitchOnSquare = SFSymbol(
         title: "lightswitch.on.square",
-        categories: [.home],
+        categories: [.home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5632,7 +5632,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let locationSlashCircle = SFSymbol(
         title: "location.slash.circle",
-        categories: [.arrows, .maps, .multicolor, .variable],
+        categories: [.arrows, .maps, .multicolor, .variable, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -5796,7 +5796,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Messages app.
     static let messageBadgeCircle = SFSymbol(
         title: "message.badge.circle",
-        categories: [.communication, .variable],
+        categories: [.communication, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -5917,7 +5917,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let microbeCircle = SFSymbol(
         title: "microbe.circle",
-        categories: [.health, .nature, .variable],
+        categories: [.health, .nature, .variable, .draw],
         searchTerms: ["COVID", "exposure", "medical", "virus"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6016,7 +6016,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let moonHazeCircle = SFSymbol(
         title: "moon.haze.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6049,7 +6049,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let moonStarsCircle = SFSymbol(
         title: "moon.stars.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6346,7 +6346,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let parkinglightFill = SFSymbol(
         title: "parkinglight.fill",
-        categories: [.automotive, .multicolor],
+        categories: [.automotive, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -6634,7 +6634,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let phoneArrowDownLeftFill = SFSymbol(
         title: "phone.arrow.down.left.fill",
-        categories: [.communication],
+        categories: [.communication, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6645,7 +6645,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let phoneArrowRightFill = SFSymbol(
         title: "phone.arrow.right.fill",
-        categories: [.communication],
+        categories: [.communication, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6656,7 +6656,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let phoneArrowUpRightCircle = SFSymbol(
         title: "phone.arrow.up.right.circle",
-        categories: [.communication, .variable],
+        categories: [.communication, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6678,7 +6678,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let phoneArrowUpRightFill = SFSymbol(
         title: "phone.arrow.up.right.fill",
-        categories: [.communication],
+        categories: [.communication, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6766,7 +6766,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pillCircle = SFSymbol(
         title: "pill.circle",
-        categories: [.health, .objectsAndTools, .variable],
+        categories: [.health, .objectsAndTools, .variable, .draw],
         searchTerms: ["medical"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6854,7 +6854,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let playpauseCircle = SFSymbol(
         title: "playpause.circle",
-        categories: [.media, .variable],
+        categories: [.media, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6900,7 +6900,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let popcornCircle = SFSymbol(
         title: "popcorn.circle",
-        categories: [.home, .objectsAndTools, .variable],
+        categories: [.home, .objectsAndTools, .variable, .draw],
         searchTerms: ["movie"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6977,7 +6977,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let poweroutletTypeASquare = SFSymbol(
         title: "poweroutlet.type.a.square",
-        categories: [.home],
+        categories: [.home, .draw],
         searchTerms: ["canada", "japan", "mexico", "united states of america", "usa"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7021,7 +7021,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let poweroutletTypeBSquare = SFSymbol(
         title: "poweroutlet.type.b.square",
-        categories: [.home],
+        categories: [.home, .draw],
         searchTerms: ["canada", "japan", "mexico", "united states of america", "usa"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7065,7 +7065,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let poweroutletTypeCSquare = SFSymbol(
         title: "poweroutlet.type.c.square",
-        categories: [.home],
+        categories: [.home, .draw],
         searchTerms: ["asia", "europe", "south america"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7109,7 +7109,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let poweroutletTypeDSquare = SFSymbol(
         title: "poweroutlet.type.d.square",
-        categories: [.home],
+        categories: [.home, .draw],
         searchTerms: ["india"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7153,7 +7153,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let poweroutletTypeESquare = SFSymbol(
         title: "poweroutlet.type.e.square",
-        categories: [.home],
+        categories: [.home, .draw],
         searchTerms: ["belgium", "czechia", "france", "poland", "slovakia"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7197,7 +7197,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let poweroutletTypeFSquare = SFSymbol(
         title: "poweroutlet.type.f.square",
-        categories: [.home],
+        categories: [.home, .draw],
         searchTerms: ["europe", "russia"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7241,7 +7241,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let poweroutletTypeGSquare = SFSymbol(
         title: "poweroutlet.type.g.square",
-        categories: [.home],
+        categories: [.home, .draw],
         searchTerms: ["ireland", "malaysia", "malta", "singapore", "uk", "united kingdom"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7285,7 +7285,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let poweroutletTypeHSquare = SFSymbol(
         title: "poweroutlet.type.h.square",
-        categories: [.home],
+        categories: [.home, .draw],
         searchTerms: ["gaza strip", "israel", "west bank"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7329,7 +7329,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let poweroutletTypeISquare = SFSymbol(
         title: "poweroutlet.type.i.square",
-        categories: [.home],
+        categories: [.home, .draw],
         searchTerms: ["argentina", "australia", "china", "new zealand"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7373,7 +7373,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let poweroutletTypeJSquare = SFSymbol(
         title: "poweroutlet.type.j.square",
-        categories: [.home],
+        categories: [.home, .draw],
         searchTerms: ["liechtenstein", "switzerland"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7417,7 +7417,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let poweroutletTypeKSquare = SFSymbol(
         title: "poweroutlet.type.k.square",
-        categories: [.home],
+        categories: [.home, .draw],
         searchTerms: ["denmark", "greenland"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7461,7 +7461,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let poweroutletTypeLSquare = SFSymbol(
         title: "poweroutlet.type.l.square",
-        categories: [.home],
+        categories: [.home, .draw],
         searchTerms: ["chile", "italy"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7505,7 +7505,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let poweroutletTypeMSquare = SFSymbol(
         title: "poweroutlet.type.m.square",
-        categories: [.home],
+        categories: [.home, .draw],
         searchTerms: ["south africa"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7549,7 +7549,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let poweroutletTypeNSquare = SFSymbol(
         title: "poweroutlet.type.n.square",
-        categories: [.home],
+        categories: [.home, .draw],
         searchTerms: ["brazil", "south africa"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7593,7 +7593,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let poweroutletTypeOSquare = SFSymbol(
         title: "poweroutlet.type.o.square",
-        categories: [.home],
+        categories: [.home, .draw],
         searchTerms: ["thailand"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7652,7 +7652,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let recordingtapeCircle = SFSymbol(
         title: "recordingtape.circle",
-        categories: [.communication, .variable],
+        categories: [.communication, .variable, .draw],
         searchTerms: ["voicemail"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7957,7 +7957,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let shippingboxAndArrowBackwardFill = SFSymbol(
         title: "shippingbox.and.arrow.backward.fill",
-        categories: [.objectsAndTools],
+        categories: [.objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8113,7 +8113,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let smokeCircle = SFSymbol(
         title: "smoke.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8146,7 +8146,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let soccerballCircle = SFSymbol(
         title: "soccerball.circle",
-        categories: [.fitness, .objectsAndTools, .variable],
+        categories: [.fitness, .objectsAndTools, .variable, .draw],
         searchTerms: ["football", "sports"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8247,7 +8247,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let speakerMinusFill = SFSymbol(
         title: "speaker.minus.fill",
-        categories: [.objectsAndTools],
+        categories: [.objectsAndTools, .draw],
         searchTerms: ["volume"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8269,7 +8269,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let speakerPlusFill = SFSymbol(
         title: "speaker.plus.fill",
-        categories: [.objectsAndTools],
+        categories: [.objectsAndTools, .draw],
         searchTerms: ["volume"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8280,7 +8280,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let speakerSquare = SFSymbol(
         title: "speaker.square",
-        categories: [.objectsAndTools],
+        categories: [.objectsAndTools, .draw],
         searchTerms: ["volume"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8354,7 +8354,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sportscourtCircle = SFSymbol(
         title: "sportscourt.circle",
-        categories: [.fitness, .variable],
+        categories: [.fitness, .variable, .draw],
         searchTerms: ["sports"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8508,7 +8508,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let squareAndPencilCircle = SFSymbol(
         title: "square.and.pencil.circle",
-        categories: [.editing, .objectsAndTools, .variable],
+        categories: [.editing, .objectsAndTools, .variable, .draw],
         searchTerms: ["compose", "mail", "write", "writing"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8768,7 +8768,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sunDustCircle = SFSymbol(
         title: "sun.dust.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8790,7 +8790,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sunHazeCircle = SFSymbol(
         title: "sun.haze.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8834,7 +8834,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sunriseCircle = SFSymbol(
         title: "sunrise.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["arrow", "weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8856,7 +8856,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sunsetCircle = SFSymbol(
         title: "sunset.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["arrow", "weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8922,7 +8922,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let switchProgrammableSquare = SFSymbol(
         title: "switch.programmable.square",
-        categories: [.home],
+        categories: [.home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9032,7 +9032,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tennisRacketCircle = SFSymbol(
         title: "tennis.racket.circle",
-        categories: [.fitness, .objectsAndTools, .variable],
+        categories: [.fitness, .objectsAndTools, .variable, .draw],
         searchTerms: ["sports"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9065,7 +9065,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tennisballCircle = SFSymbol(
         title: "tennisball.circle",
-        categories: [.fitness, .objectsAndTools, .variable],
+        categories: [.fitness, .objectsAndTools, .variable, .draw],
         searchTerms: ["sports"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9245,7 +9245,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let thermometerSnowflakeCircle = SFSymbol(
         title: "thermometer.snowflake.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9267,7 +9267,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let thermometerSunCircle = SFSymbol(
         title: "thermometer.sun.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9289,7 +9289,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let timerCircle = SFSymbol(
         title: "timer.circle",
-        categories: [.objectsAndTools, .time, .variable],
+        categories: [.objectsAndTools, .time, .variable, .draw],
         searchTerms: ["timer"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9333,7 +9333,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tornadoCircle = SFSymbol(
         title: "tornado.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9344,7 +9344,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let tornadoCircleFill = SFSymbol(
         title: "tornado.circle.fill",
-        categories: [.multicolor, .nature, .weather],
+        categories: [.multicolor, .nature, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -9366,7 +9366,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let trophyCircle = SFSymbol(
         title: "trophy.circle",
-        categories: [.fitness, .objectsAndTools, .variable],
+        categories: [.fitness, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9399,7 +9399,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tropicalstormCircle = SFSymbol(
         title: "tropicalstorm.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9546,7 +9546,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let volleyballCircle = SFSymbol(
         title: "volleyball.circle",
-        categories: [.fitness, .objectsAndTools, .variable],
+        categories: [.fitness, .objectsAndTools, .variable, .draw],
         searchTerms: ["sports"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9717,7 +9717,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let windCircle = SFSymbol(
         title: "wind.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9728,7 +9728,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let windCircleFill = SFSymbol(
         title: "wind.circle.fill",
-        categories: [.multicolor, .nature, .weather],
+        categories: [.multicolor, .nature, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -9739,7 +9739,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let windSnowCircle = SFSymbol(
         title: "wind.snow.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9750,7 +9750,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let windSnowCircleFill = SFSymbol(
         title: "wind.snow.circle.fill",
-        categories: [.multicolor, .nature, .weather],
+        categories: [.multicolor, .nature, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 16.0, macOS: 13.0, tvOS: 16.0, watchOS: 9.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables16P1.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables16P1.swift
@@ -213,7 +213,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let absCircle = SFSymbol(
         title: "abs.circle",
-        categories: [.automotive, .multicolor, .variable],
+        categories: [.automotive, .multicolor, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -385,7 +385,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let backpackCircle = SFSymbol(
         title: "backpack.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["camping"],
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -429,7 +429,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let batteryblockSlash = SFSymbol(
         title: "batteryblock.slash",
-        categories: [.automotive, .objectsAndTools],
+        categories: [.automotive, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -440,7 +440,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let batteryblockSlashFill = SFSymbol(
         title: "batteryblock.slash.fill",
-        categories: [.automotive, .objectsAndTools],
+        categories: [.automotive, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -484,7 +484,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let carFrontWavesUpFill = SFSymbol(
         title: "car.front.waves.up.fill",
-        categories: [.automotive, .devices, .transportation, .variable],
+        categories: [.automotive, .devices, .transportation, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -517,7 +517,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let carRearAndTireMarksSlash = SFSymbol(
         title: "car.rear.and.tire.marks.slash",
-        categories: [.automotive, .multicolor],
+        categories: [.automotive, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -572,7 +572,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let carRearWavesUpFill = SFSymbol(
         title: "car.rear.waves.up.fill",
-        categories: [.automotive, .variable],
+        categories: [.automotive, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1320,7 +1320,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let crossCaseCircle = SFSymbol(
         title: "cross.case.circle",
-        categories: [.health, .objectsAndTools, .variable],
+        categories: [.health, .objectsAndTools, .variable, .draw],
         searchTerms: ["first aid", "first aid kit", "firstaid", "kit", "medical"],
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1558,7 +1558,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let fishCircle = SFSymbol(
         title: "fish.circle",
-        categories: [.nature, .variable],
+        categories: [.nature, .variable, .draw],
         searchTerms: ["animals"],
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1782,7 +1782,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let houseAndFlagCircle = SFSymbol(
         title: "house.and.flag.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["campground", "camping", "ranger station"],
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1826,7 +1826,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let houseLodgeCircle = SFSymbol(
         title: "house.lodge.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["campground", "camping"],
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2014,7 +2014,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iPhone.
     static let iphoneGen1Circle = SFSymbol(
         title: "iphone.gen1.circle",
-        categories: [.devices, .variable],
+        categories: [.devices, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2066,7 +2066,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iPhone.
     static let iphoneGen1RadiowavesLeftAndRightCircle = SFSymbol(
         title: "iphone.gen1.radiowaves.left.and.right.circle",
-        categories: [.devices, .variable],
+        categories: [.devices, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2105,7 +2105,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iPhone.
     static let iphoneGen1SlashCircle = SFSymbol(
         title: "iphone.gen1.slash.circle",
-        categories: [.devices, .variable],
+        categories: [.devices, .variable, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2157,7 +2157,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iPhone.
     static let iphoneGen2Circle = SFSymbol(
         title: "iphone.gen2.circle",
-        categories: [.devices, .variable],
+        categories: [.devices, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2209,7 +2209,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iPhone.
     static let iphoneGen2RadiowavesLeftAndRightCircle = SFSymbol(
         title: "iphone.gen2.radiowaves.left.and.right.circle",
-        categories: [.devices, .variable],
+        categories: [.devices, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2248,7 +2248,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iPhone.
     static let iphoneGen2SlashCircle = SFSymbol(
         title: "iphone.gen2.slash.circle",
-        categories: [.devices, .variable],
+        categories: [.devices, .variable, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2300,7 +2300,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iPhone.
     static let iphoneGen3Circle = SFSymbol(
         title: "iphone.gen3.circle",
-        categories: [.devices, .variable],
+        categories: [.devices, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2352,7 +2352,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iPhone.
     static let iphoneGen3RadiowavesLeftAndRightCircle = SFSymbol(
         title: "iphone.gen3.radiowaves.left.and.right.circle",
-        categories: [.devices, .variable],
+        categories: [.devices, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2391,7 +2391,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iPhone.
     static let iphoneGen3SlashCircle = SFSymbol(
         title: "iphone.gen3.slash.circle",
-        categories: [.devices, .variable],
+        categories: [.devices, .variable, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2449,7 +2449,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let keyRadiowavesForwardFill = SFSymbol(
         title: "key.radiowaves.forward.fill",
-        categories: [.automotive, .objectsAndTools, .privacyAndSecurity, .variable],
+        categories: [.automotive, .objectsAndTools, .privacyAndSecurity, .variable, .draw],
         searchTerms: ["security"],
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2471,7 +2471,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let kphCircle = SFSymbol(
         title: "kph.circle",
-        categories: [.automotive, .variable],
+        categories: [.automotive, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2526,7 +2526,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let lightOverheadLeftFill = SFSymbol(
         title: "light.overhead.left.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2548,7 +2548,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let lightOverheadRightFill = SFSymbol(
         title: "light.overhead.right.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2629,7 +2629,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let minusPlusBatteryblockSlash = SFSymbol(
         title: "minus.plus.batteryblock.slash",
-        categories: [.automotive, .multicolor, .objectsAndTools],
+        categories: [.automotive, .multicolor, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -2640,7 +2640,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let minusPlusBatteryblockSlashFill = SFSymbol(
         title: "minus.plus.batteryblock.slash.fill",
-        categories: [.automotive, .multicolor, .objectsAndTools],
+        categories: [.automotive, .multicolor, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -2750,7 +2750,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let mountain2Circle = SFSymbol(
         title: "mountain.2.circle",
-        categories: [.nature, .variable],
+        categories: [.nature, .variable, .draw],
         searchTerms: ["campground", "camping", "trail"],
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2794,7 +2794,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let mphCircle = SFSymbol(
         title: "mph.circle",
-        categories: [.automotive, .variable],
+        categories: [.automotive, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2926,7 +2926,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sailboatCircle = SFSymbol(
         title: "sailboat.circle",
-        categories: [.objectsAndTools, .transportation, .variable],
+        categories: [.objectsAndTools, .transportation, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2959,7 +2959,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let signpostAndArrowtriangleUpCircle = SFSymbol(
         title: "signpost.and.arrowtriangle.up.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["campground", "camping", "trail", "trailhead"],
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2992,7 +2992,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let signpostLeftCircle = SFSymbol(
         title: "signpost.left.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["campground", "camping", "trail"],
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3025,7 +3025,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let signpostRightAndLeftCircle = SFSymbol(
         title: "signpost.right.and.left.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["campground", "camping", "fork", "trail"],
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3058,7 +3058,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let signpostRightCircle = SFSymbol(
         title: "signpost.right.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["campground", "camping", "trail"],
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3124,7 +3124,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sosCircle = SFSymbol(
         title: "sos.circle",
-        categories: [.connectivity, .variable],
+        categories: [.connectivity, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3225,7 +3225,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let steeringwheelSlash = SFSymbol(
         title: "steeringwheel.slash",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3511,7 +3511,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tent2Circle = SFSymbol(
         title: "tent.2.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["campground", "camping"],
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3544,7 +3544,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tentCircle = SFSymbol(
         title: "tent.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["campground", "camping"],
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3588,7 +3588,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let toiletCircle = SFSymbol(
         title: "toilet.circle",
-        categories: [.home, .objectsAndTools, .variable],
+        categories: [.home, .objectsAndTools, .variable, .draw],
         searchTerms: ["campground", "camping"],
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3632,7 +3632,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let treeCircle = SFSymbol(
         title: "tree.circle",
-        categories: [.multicolor, .nature, .objectsAndTools, .variable],
+        categories: [.multicolor, .nature, .objectsAndTools, .variable, .draw],
         searchTerms: ["campground", "camping"],
         releaseInfo: ReleaseInfo(iOS: 16.1, macOS: 13.0, tvOS: 16.1, watchOS: 9.1, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables17.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables17.swift
@@ -24,7 +24,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let _2hCircle = SFSymbol(
         title: "2h.circle",
-        categories: [.automotive, .variable],
+        categories: [.automotive, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -57,7 +57,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let _4aCircle = SFSymbol(
         title: "4a.circle",
-        categories: [.automotive, .variable],
+        categories: [.automotive, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -90,7 +90,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let _4hCircle = SFSymbol(
         title: "4h.circle",
-        categories: [.automotive, .variable],
+        categories: [.automotive, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -123,7 +123,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let _4lCircle = SFSymbol(
         title: "4l.circle",
-        categories: [.automotive, .variable],
+        categories: [.automotive, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -459,7 +459,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowBackwardToLineSquare = SFSymbol(
         title: "arrow.backward.to.line.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -494,7 +494,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowClockwiseSquare = SFSymbol(
         title: "arrow.clockwise.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["refresh"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -505,7 +505,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowClockwiseSquareFill = SFSymbol(
         title: "arrow.clockwise.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["refresh"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -516,7 +516,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowCounterclockwiseSquare = SFSymbol(
         title: "arrow.counterclockwise.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["revert"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -527,7 +527,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowCounterclockwiseSquareFill = SFSymbol(
         title: "arrow.counterclockwise.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: ["revert"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -562,7 +562,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownBackwardAndArrowUpForwardCircle = SFSymbol(
         title: "arrow.down.backward.and.arrow.up.forward.circle",
-        categories: [.arrows, .cameraAndPhotos, .variable],
+        categories: [.arrows, .cameraAndPhotos, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -584,7 +584,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownBackwardAndArrowUpForwardSquare = SFSymbol(
         title: "arrow.down.backward.and.arrow.up.forward.square",
-        categories: [.arrows, .cameraAndPhotos],
+        categories: [.arrows, .cameraAndPhotos, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -617,7 +617,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownBackwardToptrailingRectangleFill = SFSymbol(
         title: "arrow.down.backward.toptrailing.rectangle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -628,7 +628,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownCircleDotted = SFSymbol(
         title: "arrow.down.circle.dotted",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["download", "downloads"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -639,7 +639,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownForwardAndArrowUpBackwardSquare = SFSymbol(
         title: "arrow.down.forward.and.arrow.up.backward.square",
-        categories: [.arrows, .cameraAndPhotos],
+        categories: [.arrows, .cameraAndPhotos, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -672,7 +672,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownForwardTopleadingRectangleFill = SFSymbol(
         title: "arrow.down.forward.topleading.rectangle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -694,7 +694,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownLeftAndArrowUpRightCircle = SFSymbol(
         title: "arrow.down.left.and.arrow.up.right.circle",
-        categories: [.arrows, .cameraAndPhotos, .variable],
+        categories: [.arrows, .cameraAndPhotos, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -716,7 +716,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownLeftAndArrowUpRightSquare = SFSymbol(
         title: "arrow.down.left.and.arrow.up.right.square",
-        categories: [.arrows, .cameraAndPhotos],
+        categories: [.arrows, .cameraAndPhotos, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -749,7 +749,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownLeftArrowUpRightCircle = SFSymbol(
         title: "arrow.down.left.arrow.up.right.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -760,7 +760,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownLeftArrowUpRightCircleFill = SFSymbol(
         title: "arrow.down.left.arrow.up.right.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -771,7 +771,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownLeftArrowUpRightSquare = SFSymbol(
         title: "arrow.down.left.arrow.up.right.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -782,7 +782,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownLeftArrowUpRightSquareFill = SFSymbol(
         title: "arrow.down.left.arrow.up.right.square.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -804,7 +804,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownLeftToprightRectangleFill = SFSymbol(
         title: "arrow.down.left.topright.rectangle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -815,7 +815,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownRightAndArrowUpLeftSquare = SFSymbol(
         title: "arrow.down.right.and.arrow.up.left.square",
-        categories: [.arrows, .cameraAndPhotos],
+        categories: [.arrows, .cameraAndPhotos, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -848,7 +848,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownRightTopleftRectangleFill = SFSymbol(
         title: "arrow.down.right.topleft.rectangle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -859,7 +859,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownToLineSquare = SFSymbol(
         title: "arrow.down.to.line.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -881,7 +881,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowForwardToLineSquare = SFSymbol(
         title: "arrow.forward.to.line.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -903,7 +903,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowLeftToLineSquare = SFSymbol(
         title: "arrow.left.to.line.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -925,7 +925,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowRightToLineSquare = SFSymbol(
         title: "arrow.right.to.line.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -973,7 +973,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpBackwardAndArrowDownForwardSquare = SFSymbol(
         title: "arrow.up.backward.and.arrow.down.forward.square",
-        categories: [.arrows, .cameraAndPhotos],
+        categories: [.arrows, .cameraAndPhotos, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1006,7 +1006,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpBackwardBottomtrailingRectangleFill = SFSymbol(
         title: "arrow.up.backward.bottomtrailing.rectangle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1028,7 +1028,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpForwardAndArrowDownBackwardCircle = SFSymbol(
         title: "arrow.up.forward.and.arrow.down.backward.circle",
-        categories: [.arrows, .cameraAndPhotos, .variable],
+        categories: [.arrows, .cameraAndPhotos, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1050,7 +1050,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpForwardAndArrowDownBackwardSquare = SFSymbol(
         title: "arrow.up.forward.and.arrow.down.backward.square",
-        categories: [.arrows, .cameraAndPhotos],
+        categories: [.arrows, .cameraAndPhotos, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1083,7 +1083,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpForwardBottomleadingRectangleFill = SFSymbol(
         title: "arrow.up.forward.bottomleading.rectangle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1094,7 +1094,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpLeftAndArrowDownRightSquare = SFSymbol(
         title: "arrow.up.left.and.arrow.down.right.square",
-        categories: [.arrows, .cameraAndPhotos],
+        categories: [.arrows, .cameraAndPhotos, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1127,7 +1127,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpLeftArrowDownRightCircle = SFSymbol(
         title: "arrow.up.left.arrow.down.right.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1138,7 +1138,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpLeftArrowDownRightCircleFill = SFSymbol(
         title: "arrow.up.left.arrow.down.right.circle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1149,7 +1149,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpLeftArrowDownRightSquare = SFSymbol(
         title: "arrow.up.left.arrow.down.right.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1182,7 +1182,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpLeftBottomrightRectangleFill = SFSymbol(
         title: "arrow.up.left.bottomright.rectangle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1204,7 +1204,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpRightAndArrowDownLeftCircle = SFSymbol(
         title: "arrow.up.right.and.arrow.down.left.circle",
-        categories: [.arrows, .cameraAndPhotos, .variable],
+        categories: [.arrows, .cameraAndPhotos, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1226,7 +1226,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpRightAndArrowDownLeftSquare = SFSymbol(
         title: "arrow.up.right.and.arrow.down.left.square",
-        categories: [.arrows, .cameraAndPhotos],
+        categories: [.arrows, .cameraAndPhotos, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1259,7 +1259,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpRightBottomleftRectangleFill = SFSymbol(
         title: "arrow.up.right.bottomleft.rectangle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1270,7 +1270,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpToLineSquare = SFSymbol(
         title: "arrow.up.to.line.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1303,7 +1303,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpTrashFill = SFSymbol(
         title: "arrow.up.trash.fill",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1380,7 +1380,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowshapeBackwardCircle = SFSymbol(
         title: "arrowshape.backward.circle",
-        categories: [.arrows, .automotive, .variable],
+        categories: [.arrows, .automotive, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1413,7 +1413,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowshapeDownCircle = SFSymbol(
         title: "arrowshape.down.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1446,7 +1446,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowshapeForwardCircle = SFSymbol(
         title: "arrowshape.forward.circle",
-        categories: [.arrows, .automotive, .variable],
+        categories: [.arrows, .automotive, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1490,7 +1490,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowshapeLeftCircle = SFSymbol(
         title: "arrowshape.left.circle",
-        categories: [.arrows, .automotive, .variable],
+        categories: [.arrows, .automotive, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1512,7 +1512,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowshapeRightCircle = SFSymbol(
         title: "arrowshape.right.circle",
-        categories: [.arrows, .automotive, .variable],
+        categories: [.arrows, .automotive, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1545,7 +1545,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowshapeUpCircle = SFSymbol(
         title: "arrowshape.up.circle",
-        categories: [.arrows, .variable],
+        categories: [.arrows, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1624,7 +1624,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let australiandollarsignCircle = SFSymbol(
         title: "australiandollarsign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1646,7 +1646,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let australiandollarsignSquare = SFSymbol(
         title: "australiandollarsign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -1828,7 +1828,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let battery100PercentCircle = SFSymbol(
         title: "battery.100percent.circle",
-        categories: [.multicolor, .objectsAndTools, .variable],
+        categories: [.multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -2014,7 +2014,7 @@ public extension SFSymbol {
     /// - Localizations: Right-to-Left
     static let bellBadgeSlash = SFSymbol(
         title: "bell.badge.slash",
-        categories: [.objectsAndTools],
+        categories: [.objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2027,7 +2027,7 @@ public extension SFSymbol {
     /// - Localizations: Right-to-Left
     static let bellBadgeSlashFill = SFSymbol(
         title: "bell.badge.slash.fill",
-        categories: [.objectsAndTools],
+        categories: [.objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -2050,7 +2050,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let bellBadgeWaveformFill = SFSymbol(
         title: "bell.badge.waveform.fill",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2061,7 +2061,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let binocularsCircle = SFSymbol(
         title: "binoculars.circle",
-        categories: [.maps, .objectsAndTools, .variable],
+        categories: [.maps, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2083,7 +2083,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let birdCircle = SFSymbol(
         title: "bird.circle",
-        categories: [.nature, .variable],
+        categories: [.nature, .variable, .draw],
         searchTerms: ["animals"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2285,7 +2285,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let bubbleCircle = SFSymbol(
         title: "bubble.circle",
-        categories: [.communication, .variable],
+        categories: [.communication, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2643,7 +2643,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let carFrontWavesDownFill = SFSymbol(
         title: "car.front.waves.down.fill",
-        categories: [.automotive, .devices, .transportation, .variable],
+        categories: [.automotive, .devices, .transportation, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2687,7 +2687,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let carSideHillDownFill = SFSymbol(
         title: "car.side.hill.down.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -2709,7 +2709,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let carSideHillUpFill = SFSymbol(
         title: "car.side.hill.up.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3561,7 +3561,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let catCircle = SFSymbol(
         title: "cat.circle",
-        categories: [.nature, .variable],
+        categories: [.nature, .variable, .draw],
         searchTerms: ["animals"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3729,7 +3729,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chineseyuanrenminbisignCircle = SFSymbol(
         title: "chineseyuanrenminbisign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3751,7 +3751,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chineseyuanrenminbisignSquare = SFSymbol(
         title: "chineseyuanrenminbisign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -3944,7 +3944,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let circleDottedCircle = SFSymbol(
         title: "circle.dotted.circle",
-        categories: [.cameraAndPhotos, .variable],
+        categories: [.cameraAndPhotos, .variable, .draw],
         searchTerms: ["edit", "vignette"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4235,7 +4235,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let danishkronesignCircle = SFSymbol(
         title: "danishkronesign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4257,7 +4257,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let danishkronesignSquare = SFSymbol(
         title: "danishkronesign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4279,7 +4279,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let dishwasherCircle = SFSymbol(
         title: "dishwasher.circle",
-        categories: [.home, .objectsAndTools, .variable],
+        categories: [.home, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4368,7 +4368,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let dogCircle = SFSymbol(
         title: "dog.circle",
-        categories: [.nature, .variable],
+        categories: [.nature, .variable, .draw],
         searchTerms: ["animals"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4469,7 +4469,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let dryerCircle = SFSymbol(
         title: "dryer.circle",
-        categories: [.home, .objectsAndTools, .variable],
+        categories: [.home, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4583,7 +4583,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let eurozonesignCircle = SFSymbol(
         title: "eurozonesign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4605,7 +4605,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let eurozonesignSquare = SFSymbol(
         title: "eurozonesign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4715,7 +4715,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let evChargerSlash = SFSymbol(
         title: "ev.charger.slash",
-        categories: [.automotive, .objectsAndTools, .transportation],
+        categories: [.automotive, .objectsAndTools, .transportation, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4726,7 +4726,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let evChargerSlashFill = SFSymbol(
         title: "ev.charger.slash.fill",
-        categories: [.automotive, .objectsAndTools, .transportation],
+        categories: [.automotive, .objectsAndTools, .transportation, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -4946,7 +4946,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let exclamationmarkWarninglightFill = SFSymbol(
         title: "exclamationmark.warninglight.fill",
-        categories: [.automotive, .multicolor],
+        categories: [.automotive, .multicolor, .draw],
         searchTerms: ["!", "error", "light", "warning"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4957,7 +4957,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let eyeglassesSlash = SFSymbol(
         title: "eyeglasses.slash",
-        categories: [.objectsAndTools],
+        categories: [.objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5012,7 +5012,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let fanSlash = SFSymbol(
         title: "fan.slash",
-        categories: [.automotive, .home, .objectsAndTools],
+        categories: [.automotive, .home, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5023,7 +5023,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let fanSlashFill = SFSymbol(
         title: "fan.slash.fill",
-        categories: [.automotive, .home, .objectsAndTools],
+        categories: [.automotive, .home, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5100,7 +5100,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figure2Circle = SFSymbol(
         title: "figure.2.circle",
-        categories: [.accessibility, .human, .variable],
+        categories: [.accessibility, .human, .variable, .draw],
         searchTerms: ["human", "person"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5177,7 +5177,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureChildCircle = SFSymbol(
         title: "figure.child.circle",
-        categories: [.automotive, .human, .variable],
+        categories: [.automotive, .human, .variable, .draw],
         searchTerms: ["human", "person"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5442,7 +5442,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let flashlightOffCircle = SFSymbol(
         title: "flashlight.off.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5464,7 +5464,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let flashlightOnCircle = SFSymbol(
         title: "flashlight.on.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5486,7 +5486,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let flashlightSlash = SFSymbol(
         title: "flashlight.slash",
-        categories: [.objectsAndTools],
+        categories: [.objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5497,7 +5497,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let flashlightSlashCircle = SFSymbol(
         title: "flashlight.slash.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5633,7 +5633,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let fuelpumpSlash = SFSymbol(
         title: "fuelpump.slash",
-        categories: [.automotive, .objectsAndTools, .transportation],
+        categories: [.automotive, .objectsAndTools, .transportation, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5644,7 +5644,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let fuelpumpSlashFill = SFSymbol(
         title: "fuelpump.slash.fill",
-        categories: [.automotive, .objectsAndTools, .transportation],
+        categories: [.automotive, .objectsAndTools, .transportation, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5916,7 +5916,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let handPointUpLeftAndTextFill = SFSymbol(
         title: "hand.point.up.left.and.text.fill",
-        categories: [.human],
+        categories: [.human, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5927,7 +5927,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let handbagCircle = SFSymbol(
         title: "handbag.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -5982,7 +5982,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let hareCircle = SFSymbol(
         title: "hare.circle",
-        categories: [.accessibility, .nature, .variable],
+        categories: [.accessibility, .nature, .variable, .draw],
         searchTerms: ["animals", "fast", "rabbit"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6222,7 +6222,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let keySlash = SFSymbol(
         title: "key.slash",
-        categories: [.automotive, .objectsAndTools, .privacyAndSecurity],
+        categories: [.automotive, .objectsAndTools, .privacyAndSecurity, .draw],
         searchTerms: ["password", "security"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6233,7 +6233,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let keySlashFill = SFSymbol(
         title: "key.slash.fill",
-        categories: [.automotive, .objectsAndTools, .privacyAndSecurity],
+        categories: [.automotive, .objectsAndTools, .privacyAndSecurity, .draw],
         searchTerms: ["password", "security"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6433,7 +6433,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let ladybugCircle = SFSymbol(
         title: "ladybug.circle",
-        categories: [.nature, .variable],
+        categories: [.nature, .variable, .draw],
         searchTerms: ["animals", "bug"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6545,7 +6545,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let leftCircle = SFSymbol(
         title: "left.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6600,7 +6600,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let lightbulbMaxFill = SFSymbol(
         title: "lightbulb.max.fill",
-        categories: [.home, .objectsAndTools],
+        categories: [.home, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -6747,7 +6747,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let lizardCircle = SFSymbol(
         title: "lizard.circle",
-        categories: [.nature, .variable],
+        categories: [.nature, .variable, .draw],
         searchTerms: ["animals", "reptile"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7069,7 +7069,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let mappinAndEllipseCircle = SFSymbol(
         title: "mappin.and.ellipse.circle",
-        categories: [.maps, .multicolor, .objectsAndTools, .variable],
+        categories: [.maps, .multicolor, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -7105,7 +7105,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Messages app.
     static let messageBadgeWaveformFill = SFSymbol(
         title: "message.badge.waveform.fill",
-        categories: [.communication, .variable],
+        categories: [.communication, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -7141,7 +7141,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let moonDustCircle = SFSymbol(
         title: "moon.dust.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7185,7 +7185,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let moonriseCircle = SFSymbol(
         title: "moonrise.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: ["arrow", "weather"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7229,7 +7229,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let moonsetCircle = SFSymbol(
         title: "moonset.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: ["arrow", "weather"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7297,7 +7297,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let networkSlash = SFSymbol(
         title: "network.slash",
-        categories: [.connectivity, .multicolor],
+        categories: [.connectivity, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -7332,7 +7332,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let norwegiankronesignCircle = SFSymbol(
         title: "norwegiankronesign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7354,7 +7354,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let norwegiankronesignSquare = SFSymbol(
         title: "norwegiankronesign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7790,7 +7790,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let personBustCircle = SFSymbol(
         title: "person.bust.circle",
-        categories: [.human, .objectsAndTools, .variable],
+        categories: [.human, .objectsAndTools, .variable, .draw],
         searchTerms: ["art", "people", "sculpture"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7812,7 +7812,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let personCropCircleDashedCircle = SFSymbol(
         title: "person.crop.circle.dashed.circle",
-        categories: [.human, .variable],
+        categories: [.human, .variable, .draw],
         searchTerms: ["people"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7834,7 +7834,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let personSlash = SFSymbol(
         title: "person.slash",
-        categories: [.human],
+        categories: [.human, .draw],
         searchTerms: ["people", "user"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7845,7 +7845,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let personSlashFill = SFSymbol(
         title: "person.slash.fill",
-        categories: [.human],
+        categories: [.human, .draw],
         searchTerms: ["people", "user"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7893,7 +7893,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let phoneBadgeWaveformFill = SFSymbol(
         title: "phone.badge.waveform.fill",
-        categories: [.communication, .variable],
+        categories: [.communication, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -7930,7 +7930,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let photoArtframeCircle = SFSymbol(
         title: "photo.artframe.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["environment", "image", "mountain", "photograph", "picture", "place", "sun"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8099,7 +8099,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pointBottomleftForwardToPointToprightScurvepathFill = SFSymbol(
         title: "point.bottomleft.forward.to.point.topright.scurvepath.fill",
-        categories: [.maps],
+        categories: [.maps, .draw],
         searchTerms: ["activities", "path", "trail"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8143,7 +8143,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pointTopleftDownToPointBottomrightCurvepathFill = SFSymbol(
         title: "point.topleft.down.to.point.bottomright.curvepath.fill",
-        categories: [.maps],
+        categories: [.maps, .draw],
         searchTerms: ["activities", "path", "trail"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8200,7 +8200,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let polishzlotysignCircle = SFSymbol(
         title: "polishzlotysign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8222,7 +8222,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let polishzlotysignSquare = SFSymbol(
         title: "polishzlotysign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8756,7 +8756,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rightCircle = SFSymbol(
         title: "right.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -8844,7 +8844,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rotate3DCircle = SFSymbol(
         title: "rotate.3d.circle",
-        categories: [.editing, .variable],
+        categories: [.editing, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9076,7 +9076,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let shoeCircle = SFSymbol(
         title: "shoe.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9454,7 +9454,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let steeringwheelCircle = SFSymbol(
         title: "steeringwheel.circle",
-        categories: [.automotive, .variable],
+        categories: [.automotive, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9500,7 +9500,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let storefrontCircle = SFSymbol(
         title: "storefront.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9544,7 +9544,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sunHorizonCircle = SFSymbol(
         title: "sun.horizon.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9588,7 +9588,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sunRainCircle = SFSymbol(
         title: "sun.rain.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9632,7 +9632,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sunSnowCircle = SFSymbol(
         title: "sun.snow.circle",
-        categories: [.nature, .variable, .weather],
+        categories: [.nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9720,7 +9720,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let suvSideHillDownFill = SFSymbol(
         title: "suv.side.hill.down.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9742,7 +9742,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let suvSideHillUpFill = SFSymbol(
         title: "suv.side.hill.up.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9821,7 +9821,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let swedishkronasignCircle = SFSymbol(
         title: "swedishkronasign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9843,7 +9843,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let swedishkronasignSquare = SFSymbol(
         title: "swedishkronasign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9924,7 +9924,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let thermometerVariableAndFigureCircle = SFSymbol(
         title: "thermometer.variable.and.figure.circle",
-        categories: [.health, .nature, .variable, .weather],
+        categories: [.health, .nature, .variable, .weather, .draw],
         searchTerms: ["feels like", "weather"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -9957,7 +9957,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tortoiseCircle = SFSymbol(
         title: "tortoise.circle",
-        categories: [.accessibility, .nature, .variable],
+        categories: [.accessibility, .nature, .variable, .draw],
         searchTerms: ["animals", "slow", "turtle"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10269,7 +10269,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let truckPickupSideHillDownFill = SFSymbol(
         title: "truck.pickup.side.hill.down.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10291,7 +10291,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let truckPickupSideHillUpFill = SFSymbol(
         title: "truck.pickup.side.hill.up.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10346,7 +10346,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tshirtCircle = SFSymbol(
         title: "tshirt.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10427,7 +10427,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tvSlashFill = SFSymbol(
         title: "tv.slash.fill",
-        categories: [.devices],
+        categories: [.devices, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10452,7 +10452,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
     static let videoBadgeWaveformFill = SFSymbol(
         title: "video.badge.waveform.fill",
-        categories: [.communication, .variable],
+        categories: [.communication, .variable, .draw],
         searchTerms: ["facetime"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical],
@@ -10495,7 +10495,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s FaceTime app.
     static let videoSlashCircle = SFSymbol(
         title: "video.slash.circle",
-        categories: [.communication, .multicolor, .variable],
+        categories: [.communication, .multicolor, .variable, .draw],
         searchTerms: ["facetime", "remove"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -10748,7 +10748,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let warninglightFill = SFSymbol(
         title: "warninglight.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10759,7 +10759,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let washerCircle = SFSymbol(
         title: "washer.circle",
-        categories: [.home, .objectsAndTools, .variable],
+        categories: [.home, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]
@@ -10849,7 +10849,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let wifiExclamationmarkCircle = SFSymbol(
         title: "wifi.exclamationmark.circle",
-        categories: [.connectivity, .variable],
+        categories: [.connectivity, .variable, .draw],
         searchTerms: ["warning"],
         releaseInfo: ReleaseInfo(iOS: 17.0, macOS: 14.0, tvOS: 17.0, watchOS: 10.0, visionOS: 1.0),
         layersets: [.monochrome, .hierarchical]

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables17P4.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables17P4.swift
@@ -52,7 +52,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let appleTerminalCircle = SFSymbol(
         title: "apple.terminal.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 17.4, macOS: 14.4, tvOS: 17.4, watchOS: 10.4, visionOS: 1.1),
         layersets: [.monochrome, .hierarchical]

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables18.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables18.swift
@@ -336,7 +336,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s AirPlay.
     static let airplayAudioCircle = SFSymbol(
         title: "airplay.audio.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical],
@@ -388,7 +388,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s AirPlay.
     static let airplayVideoCircle = SFSymbol(
         title: "airplay.video.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical],
@@ -479,7 +479,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s AirPods Pro.
     static let airpodsProChargingcaseWirelessRadiowavesLeftAndRightFill = SFSymbol(
         title: "airpods.pro.chargingcase.wireless.radiowaves.left.and.right.fill",
-        categories: [.devices, .variable],
+        categories: [.devices, .variable, .draw],
         searchTerms: ["audio"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical],
@@ -528,7 +528,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let americanFootballCircle = SFSymbol(
         title: "american.football.circle",
-        categories: [.fitness, .objectsAndTools, .variable],
+        categories: [.fitness, .objectsAndTools, .variable, .draw],
         searchTerms: ["sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -572,7 +572,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let americanFootballProfessionalCircle = SFSymbol(
         title: "american.football.professional.circle",
-        categories: [.fitness, .objectsAndTools, .variable],
+        categories: [.fitness, .objectsAndTools, .variable, .draw],
         searchTerms: ["sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -605,7 +605,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let antennaRadiowavesLeftAndRightSlashCircle = SFSymbol(
         title: "antenna.radiowaves.left.and.right.slash.circle",
-        categories: [.connectivity, .objectsAndTools, .variable],
+        categories: [.connectivity, .objectsAndTools, .variable, .draw],
         searchTerms: ["cellular", "lte", "remove"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -754,7 +754,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Meditation in Fitness+.
     static let appleMeditateCircle = SFSymbol(
         title: "apple.meditate.circle",
-        categories: [.health, .nature, .variable],
+        categories: [.health, .nature, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical],
@@ -842,7 +842,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowBackwardCircleDotted = SFSymbol(
         title: "arrow.backward.circle.dotted",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -853,7 +853,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownBackwardAndArrowUpForwardRectangle = SFSymbol(
         title: "arrow.down.backward.and.arrow.up.forward.rectangle",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -864,7 +864,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownBackwardAndArrowUpForwardRectangleFill = SFSymbol(
         title: "arrow.down.backward.and.arrow.up.forward.rectangle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -875,7 +875,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownBackwardCircleDotted = SFSymbol(
         title: "arrow.down.backward.circle.dotted",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -897,7 +897,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownDocumentFill = SFSymbol(
         title: "arrow.down.document.fill",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -908,7 +908,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownForwardAndArrowUpBackwardRectangle = SFSymbol(
         title: "arrow.down.forward.and.arrow.up.backward.rectangle",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -919,7 +919,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownForwardAndArrowUpBackwardRectangleFill = SFSymbol(
         title: "arrow.down.forward.and.arrow.up.backward.rectangle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -930,7 +930,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownForwardCircleDotted = SFSymbol(
         title: "arrow.down.forward.circle.dotted",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -941,7 +941,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownLeftAndArrowUpRightRectangle = SFSymbol(
         title: "arrow.down.left.and.arrow.up.right.rectangle",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -952,7 +952,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownLeftAndArrowUpRightRectangleFill = SFSymbol(
         title: "arrow.down.left.and.arrow.up.right.rectangle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -963,7 +963,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownLeftCircleDotted = SFSymbol(
         title: "arrow.down.left.circle.dotted",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -974,7 +974,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownRightAndArrowUpLeftRectangle = SFSymbol(
         title: "arrow.down.right.and.arrow.up.left.rectangle",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -985,7 +985,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowDownRightAndArrowUpLeftRectangleFill = SFSymbol(
         title: "arrow.down.right.and.arrow.up.left.rectangle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -996,7 +996,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowDownRightCircleDotted = SFSymbol(
         title: "arrow.down.right.circle.dotted",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1007,7 +1007,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowForwardCircleDotted = SFSymbol(
         title: "arrow.forward.circle.dotted",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1018,7 +1018,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowLeftCircleDotted = SFSymbol(
         title: "arrow.left.circle.dotted",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1029,7 +1029,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowRightCircleDotted = SFSymbol(
         title: "arrow.right.circle.dotted",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1095,7 +1095,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowTrianglehead2ClockwiseRotate90CameraFill = SFSymbol(
         title: "arrow.trianglehead.2.clockwise.rotate.90.camera.fill",
-        categories: [.cameraAndPhotos, .multicolor, .objectsAndTools],
+        categories: [.cameraAndPhotos, .multicolor, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1106,7 +1106,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowTrianglehead2ClockwiseRotate90Circle = SFSymbol(
         title: "arrow.trianglehead.2.clockwise.rotate.90.circle",
-        categories: [.arrows, .cameraAndPhotos],
+        categories: [.arrows, .cameraAndPhotos, .draw],
         searchTerms: ["sync", "syncing"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1117,7 +1117,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowTrianglehead2ClockwiseRotate90CircleFill = SFSymbol(
         title: "arrow.trianglehead.2.clockwise.rotate.90.circle.fill",
-        categories: [.arrows, .cameraAndPhotos, .multicolor],
+        categories: [.arrows, .cameraAndPhotos, .multicolor, .draw],
         searchTerms: ["sync", "syncing"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1129,7 +1129,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
     static let arrowTrianglehead2ClockwiseRotate90Icloud = SFSymbol(
         title: "arrow.trianglehead.2.clockwise.rotate.90.icloud",
-        categories: [.connectivity],
+        categories: [.connectivity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical],
@@ -1142,7 +1142,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
     static let arrowTrianglehead2ClockwiseRotate90IcloudFill = SFSymbol(
         title: "arrow.trianglehead.2.clockwise.rotate.90.icloud.fill",
-        categories: [.connectivity, .multicolor],
+        categories: [.connectivity, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -1231,7 +1231,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowTriangleheadClockwiseHeartFill = SFSymbol(
         title: "arrow.trianglehead.clockwise.heart.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1243,7 +1243,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
     static let arrowTriangleheadClockwiseIcloud = SFSymbol(
         title: "arrow.trianglehead.clockwise.icloud",
-        categories: [.connectivity],
+        categories: [.connectivity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical],
@@ -1256,7 +1256,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
     static let arrowTriangleheadClockwiseIcloudFill = SFSymbol(
         title: "arrow.trianglehead.clockwise.icloud.fill",
-        categories: [.connectivity, .multicolor],
+        categories: [.connectivity, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -1291,7 +1291,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
     static let arrowTriangleheadCounterclockwiseIcloud = SFSymbol(
         title: "arrow.trianglehead.counterclockwise.icloud",
-        categories: [.connectivity],
+        categories: [.connectivity, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical],
@@ -1304,7 +1304,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s iCloud service.
     static let arrowTriangleheadCounterclockwiseIcloudFill = SFSymbol(
         title: "arrow.trianglehead.counterclockwise.icloud.fill",
-        categories: [.connectivity, .multicolor],
+        categories: [.connectivity, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -1338,7 +1338,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowTriangleheadLeftAndRightRighttriangleLeftRighttriangleRightFill = SFSymbol(
         title: "arrow.trianglehead.left.and.right.righttriangle.left.righttriangle.right.fill",
-        categories: [.cameraAndPhotos, .editing],
+        categories: [.cameraAndPhotos, .editing, .draw],
         searchTerms: ["flip horizontal"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1404,7 +1404,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowTriangleheadTurnUpRightCircle = SFSymbol(
         title: "arrow.trianglehead.turn.up.right.circle",
-        categories: [.arrows, .maps, .multicolor, .variable],
+        categories: [.arrows, .maps, .multicolor, .variable, .draw],
         searchTerms: ["directions"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1415,7 +1415,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowTriangleheadTurnUpRightCircleFill = SFSymbol(
         title: "arrow.trianglehead.turn.up.right.circle.fill",
-        categories: [.arrows, .maps, .multicolor],
+        categories: [.arrows, .maps, .multicolor, .draw],
         searchTerms: ["directions"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1426,7 +1426,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowTriangleheadTurnUpRightDiamond = SFSymbol(
         title: "arrow.trianglehead.turn.up.right.diamond",
-        categories: [.arrows, .maps],
+        categories: [.arrows, .maps, .draw],
         searchTerms: ["directions"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1437,7 +1437,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowTriangleheadTurnUpRightDiamondFill = SFSymbol(
         title: "arrow.trianglehead.turn.up.right.diamond.fill",
-        categories: [.arrows, .maps, .multicolor],
+        categories: [.arrows, .maps, .multicolor, .draw],
         searchTerms: ["directions"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1459,7 +1459,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowTriangleheadUpAndDownRighttriangleUpRighttriangleDownFill = SFSymbol(
         title: "arrow.trianglehead.up.and.down.righttriangle.up.righttriangle.down.fill",
-        categories: [.cameraAndPhotos, .editing],
+        categories: [.cameraAndPhotos, .editing, .draw],
         searchTerms: ["flip vertical"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1470,7 +1470,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpBackwardAndArrowDownForwardRectangle = SFSymbol(
         title: "arrow.up.backward.and.arrow.down.forward.rectangle",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1481,7 +1481,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpBackwardAndArrowDownForwardRectangleFill = SFSymbol(
         title: "arrow.up.backward.and.arrow.down.forward.rectangle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1492,7 +1492,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpBackwardCircleDotted = SFSymbol(
         title: "arrow.up.backward.circle.dotted",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["left"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1503,7 +1503,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpCircleDotted = SFSymbol(
         title: "arrow.up.circle.dotted",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1525,7 +1525,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpDocumentFill = SFSymbol(
         title: "arrow.up.document.fill",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1536,7 +1536,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpForwardAndArrowDownBackwardRectangle = SFSymbol(
         title: "arrow.up.forward.and.arrow.down.backward.rectangle",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1547,7 +1547,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpForwardAndArrowDownBackwardRectangleFill = SFSymbol(
         title: "arrow.up.forward.and.arrow.down.backward.rectangle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1558,7 +1558,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpForwardCircleDotted = SFSymbol(
         title: "arrow.up.forward.circle.dotted",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["right"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1569,7 +1569,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpLeftAndArrowDownRightRectangle = SFSymbol(
         title: "arrow.up.left.and.arrow.down.right.rectangle",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1580,7 +1580,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let arrowUpLeftAndArrowDownRightRectangleFill = SFSymbol(
         title: "arrow.up.left.and.arrow.down.right.rectangle.fill",
-        categories: [.arrows, .multicolor],
+        categories: [.arrows, .multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1591,7 +1591,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpLeftCircleDotted = SFSymbol(
         title: "arrow.up.left.circle.dotted",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1613,7 +1613,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let arrowUpRightCircleDotted = SFSymbol(
         title: "arrow.up.right.circle.dotted",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1635,7 +1635,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let australianFootballCircle = SFSymbol(
         title: "australian.football.circle",
-        categories: [.fitness, .objectsAndTools, .variable],
+        categories: [.fitness, .objectsAndTools, .variable, .draw],
         searchTerms: ["sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1668,7 +1668,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let australiandollarsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "australiandollarsign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1723,7 +1723,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let australiandollarsignRing = SFSymbol(
         title: "australiandollarsign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1745,7 +1745,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let australsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "australsign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1800,7 +1800,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let australsignRing = SFSymbol(
         title: "australsign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1822,7 +1822,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let bahtsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "bahtsign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -1877,7 +1877,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let bahtsignRing = SFSymbol(
         title: "bahtsign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -2154,7 +2154,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let bitcoinsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "bitcoinsign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -2209,7 +2209,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let bitcoinsignRing = SFSymbol(
         title: "bitcoinsign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -2231,7 +2231,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let brazilianrealsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "brazilianrealsign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -2286,7 +2286,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let brazilianrealsignRing = SFSymbol(
         title: "brazilianrealsign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -2332,7 +2332,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cameraMacroSlash = SFSymbol(
         title: "camera.macro.slash",
-        categories: [.cameraAndPhotos, .nature],
+        categories: [.cameraAndPhotos, .nature, .draw],
         searchTerms: ["macro"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -2343,7 +2343,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cameraMacroSlashCircle = SFSymbol(
         title: "camera.macro.slash.circle",
-        categories: [.cameraAndPhotos, .nature, .variable],
+        categories: [.cameraAndPhotos, .nature, .variable, .draw],
         searchTerms: ["macro"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -2442,7 +2442,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let carFrontWavesLeftAndRightAndUpFill = SFSymbol(
         title: "car.front.waves.left.and.right.and.up.fill",
-        categories: [.automotive, .devices, .transportation, .variable],
+        categories: [.automotive, .devices, .transportation, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -2662,7 +2662,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let carSideHillDescentControlFill = SFSymbol(
         title: "car.side.hill.descent.control.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: ["DSR"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -3040,7 +3040,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cedisignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "cedisign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -3095,7 +3095,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cedisignRing = SFSymbol(
         title: "cedisign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -3117,7 +3117,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let centsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "centsign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -3172,7 +3172,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let centsignRing = SFSymbol(
         title: "centsign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -3195,7 +3195,7 @@ public extension SFSymbol {
     /// - Localizations: Arabic, Bengali, Gujarati, Hebrew, Hindi, Japanese, Kannada, Korean, Malayalam, Marathi, Odia, Punjabi, Sinhala, Tamil, Telugu, Thai, Chinese
     static let characterCircle = SFSymbol(
         title: "character.circle",
-        categories: [.textFormatting, .variable],
+        categories: [.textFormatting, .variable, .draw],
         searchTerms: ["a"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical],
@@ -3243,7 +3243,7 @@ public extension SFSymbol {
     /// - Localizations: Arabic, Bengali, Gujarati, Hebrew, Hindi, Japanese, Kannada, Korean, Malayalam, Marathi, Odia, Punjabi, Sinhala, Tamil, Telugu, Thai, Chinese
     static let characterSquare = SFSymbol(
         title: "character.square",
-        categories: [.textFormatting],
+        categories: [.textFormatting, .draw],
         searchTerms: ["a"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical],
@@ -3349,7 +3349,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let checkmarkArrowTriangleheadCounterclockwise = SFSymbol(
         title: "checkmark.arrow.trianglehead.counterclockwise",
-        categories: [.arrows, .media],
+        categories: [.arrows, .media, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -3551,7 +3551,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chevronUpChevronDownSquare = SFSymbol(
         title: "chevron.up.chevron.down.square",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -3639,7 +3639,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chineseyuanrenminbisignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "chineseyuanrenminbisign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -3694,7 +3694,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let chineseyuanrenminbisignRing = SFSymbol(
         title: "chineseyuanrenminbisign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -3738,7 +3738,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let clockArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "clock.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .time],
+        categories: [.arrows, .time, .draw],
         searchTerms: ["time", "time machine", "timemachine"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -3760,7 +3760,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let cloudRainbowCropFill = SFSymbol(
         title: "cloud.rainbow.crop.fill",
-        categories: [.multicolor, .nature, .variable, .weather],
+        categories: [.multicolor, .nature, .variable, .weather, .draw],
         searchTerms: ["weather"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -3793,7 +3793,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let coloncurrencysignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "coloncurrencysign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -3848,7 +3848,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let coloncurrencysignRing = SFSymbol(
         title: "coloncurrencysign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -3958,7 +3958,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let convertibleSideArrowTriangleheadBackwardFill = SFSymbol(
         title: "convertible.side.arrow.trianglehead.backward.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -3991,7 +3991,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let convertibleSideArrowTriangleheadForwardAndBackwardFill = SFSymbol(
         title: "convertible.side.arrow.trianglehead.forward.and.backward.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -4002,7 +4002,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let convertibleSideArrowTriangleheadForwardFill = SFSymbol(
         title: "convertible.side.arrow.trianglehead.forward.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -4145,7 +4145,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let convertibleSideHillDescentControlFill = SFSymbol(
         title: "convertible.side.hill.descent.control.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: ["DSR"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -4167,7 +4167,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let convertibleSideHillDownFill = SFSymbol(
         title: "convertible.side.hill.down.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -4189,7 +4189,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let convertibleSideHillUpFill = SFSymbol(
         title: "convertible.side.hill.up.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -4244,7 +4244,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cruzeirosignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "cruzeirosign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -4299,7 +4299,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cruzeirosignRing = SFSymbol(
         title: "cruzeirosign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -4343,7 +4343,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let danishkronesignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "danishkronesign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -4398,7 +4398,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let danishkronesignRing = SFSymbol(
         title: "danishkronesign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -4466,7 +4466,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let distributeHorizontalFill = SFSymbol(
         title: "distribute.horizontal.fill",
-        categories: [.editing],
+        categories: [.editing, .draw],
         searchTerms: ["rectangle", "shape"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -4488,7 +4488,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let distributeVerticalFill = SFSymbol(
         title: "distribute.vertical.fill",
-        categories: [.editing],
+        categories: [.editing, .draw],
         searchTerms: ["rectangle", "shape"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -4620,7 +4620,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let documentCircle = SFSymbol(
         title: "document.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["document"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -4719,7 +4719,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let dollarsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "dollarsign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -4774,7 +4774,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let dollarsignRing = SFSymbol(
         title: "dollarsign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -4796,7 +4796,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let dongsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "dongsign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -4851,7 +4851,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let dongsignRing = SFSymbol(
         title: "dongsign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5005,7 +5005,7 @@ public extension SFSymbol {
     /// - Localizations: Right-to-Left
     static let envelopeFrontFill = SFSymbol(
         title: "envelope.front.fill",
-        categories: [.communication, .multicolor],
+        categories: [.communication, .multicolor, .draw],
         searchTerms: ["address", "letter", "mail"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .multicolor],
@@ -5017,7 +5017,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let eurosignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "eurosign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5072,7 +5072,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let eurosignRing = SFSymbol(
         title: "eurosign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5094,7 +5094,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let eurozonesignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "eurozonesign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5149,7 +5149,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let eurozonesignRing = SFSymbol(
         title: "eurozonesign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5171,7 +5171,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let exclamationmarkArrowTrianglehead2ClockwiseRotate90 = SFSymbol(
         title: "exclamationmark.arrow.trianglehead.2.clockwise.rotate.90",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: ["sync", "syncing", "warning"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5182,7 +5182,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let exclamationmarkArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "exclamationmark.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .time],
+        categories: [.arrows, .time, .draw],
         searchTerms: ["time", "time machine", "timemachine", "warning"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5215,7 +5215,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureAmericanFootballCircle = SFSymbol(
         title: "figure.american.football.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5237,7 +5237,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureArcheryCircle = SFSymbol(
         title: "figure.archery.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5259,7 +5259,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureAustralianFootballCircle = SFSymbol(
         title: "figure.australian.football.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5281,7 +5281,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureBadmintonCircle = SFSymbol(
         title: "figure.badminton.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5303,7 +5303,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureBarreCircle = SFSymbol(
         title: "figure.barre.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5325,7 +5325,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureBaseballCircle = SFSymbol(
         title: "figure.baseball.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5347,7 +5347,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureBasketballCircle = SFSymbol(
         title: "figure.basketball.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5369,7 +5369,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureBowlingCircle = SFSymbol(
         title: "figure.bowling.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5391,7 +5391,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureBoxingCircle = SFSymbol(
         title: "figure.boxing.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5413,7 +5413,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureClimbingCircle = SFSymbol(
         title: "figure.climbing.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5435,7 +5435,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureCooldownCircle = SFSymbol(
         title: "figure.cooldown.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5457,7 +5457,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureCoreTrainingCircle = SFSymbol(
         title: "figure.core.training.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5479,7 +5479,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureCricketCircle = SFSymbol(
         title: "figure.cricket.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5501,7 +5501,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureCrossTrainingCircle = SFSymbol(
         title: "figure.cross.training.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5523,7 +5523,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureCurlingCircle = SFSymbol(
         title: "figure.curling.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5545,7 +5545,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureDanceCircle = SFSymbol(
         title: "figure.dance.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5567,7 +5567,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureDiscSportsCircle = SFSymbol(
         title: "figure.disc.sports.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5589,7 +5589,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureEllipticalCircle = SFSymbol(
         title: "figure.elliptical.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5611,7 +5611,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureEquestrianSportsCircle = SFSymbol(
         title: "figure.equestrian.sports.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5633,7 +5633,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureFencingCircle = SFSymbol(
         title: "figure.fencing.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5688,7 +5688,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureFishingCircle = SFSymbol(
         title: "figure.fishing.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5710,7 +5710,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureFlexibilityCircle = SFSymbol(
         title: "figure.flexibility.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5732,7 +5732,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureGolfCircle = SFSymbol(
         title: "figure.golf.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5754,7 +5754,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureGymnasticsCircle = SFSymbol(
         title: "figure.gymnastics.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5776,7 +5776,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureHandCyclingCircle = SFSymbol(
         title: "figure.hand.cycling.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5798,7 +5798,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureHandballCircle = SFSymbol(
         title: "figure.handball.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5820,7 +5820,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureHighintensityIntervaltrainingCircle = SFSymbol(
         title: "figure.highintensity.intervaltraining.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["hiit", "human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5842,7 +5842,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureHikingCircle = SFSymbol(
         title: "figure.hiking.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5864,7 +5864,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureHockeyCircle = SFSymbol(
         title: "figure.hockey.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5886,7 +5886,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureHuntingCircle = SFSymbol(
         title: "figure.hunting.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5952,7 +5952,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureIceSkatingCircle = SFSymbol(
         title: "figure.ice.skating.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -5974,7 +5974,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureIndoorCycleCircle = SFSymbol(
         title: "figure.indoor.cycle.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6007,7 +6007,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureIndoorRowingCircle = SFSymbol(
         title: "figure.indoor.rowing.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6040,7 +6040,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureIndoorSoccerCircle = SFSymbol(
         title: "figure.indoor.soccer.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6062,7 +6062,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureJumpropeCircle = SFSymbol(
         title: "figure.jumprope.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6084,7 +6084,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureKickboxingCircle = SFSymbol(
         title: "figure.kickboxing.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6106,7 +6106,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureLacrosseCircle = SFSymbol(
         title: "figure.lacrosse.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6128,7 +6128,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureMartialArtsCircle = SFSymbol(
         title: "figure.martial.arts.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6150,7 +6150,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureMindAndBodyCircle = SFSymbol(
         title: "figure.mind.and.body.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6172,7 +6172,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureMixedCardioCircle = SFSymbol(
         title: "figure.mixed.cardio.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6194,7 +6194,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureOpenWaterSwimCircle = SFSymbol(
         title: "figure.open.water.swim.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports", "water"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6216,7 +6216,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureOutdoorCycleCircle = SFSymbol(
         title: "figure.outdoor.cycle.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["bicycle", "human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6249,7 +6249,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureOutdoorRowingCircle = SFSymbol(
         title: "figure.outdoor.rowing.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6282,7 +6282,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureOutdoorSoccerCircle = SFSymbol(
         title: "figure.outdoor.soccer.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6304,7 +6304,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figurePickleballCircle = SFSymbol(
         title: "figure.pickleball.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6326,7 +6326,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figurePilatesCircle = SFSymbol(
         title: "figure.pilates.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6348,7 +6348,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figurePlayCircle = SFSymbol(
         title: "figure.play.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6370,7 +6370,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figurePoolSwimCircle = SFSymbol(
         title: "figure.pool.swim.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports", "water"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6392,7 +6392,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureRacquetballCircle = SFSymbol(
         title: "figure.racquetball.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6414,7 +6414,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureRollCircle = SFSymbol(
         title: "figure.roll.circle",
-        categories: [.accessibility, .fitness, .human, .variable],
+        categories: [.accessibility, .fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports", "wheelchair"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6436,7 +6436,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureRollRunningpaceCircle = SFSymbol(
         title: "figure.roll.runningpace.circle",
-        categories: [.accessibility, .fitness, .human, .variable],
+        categories: [.accessibility, .fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports", "wheelchair"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6458,7 +6458,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureRollingCircle = SFSymbol(
         title: "figure.rolling.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6480,7 +6480,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureRugbyCircle = SFSymbol(
         title: "figure.rugby.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6513,7 +6513,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureRunTreadmillCircle = SFSymbol(
         title: "figure.run.treadmill.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "indoor run", "person", "running", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -6535,7 +6535,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureSailingCircle = SFSymbol(
         title: "figure.sailing.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7382,7 +7382,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureSkateboardingCircle = SFSymbol(
         title: "figure.skateboarding.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7404,7 +7404,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureSkiingCrosscountryCircle = SFSymbol(
         title: "figure.skiing.crosscountry.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7426,7 +7426,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureSkiingDownhillCircle = SFSymbol(
         title: "figure.skiing.downhill.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7448,7 +7448,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureSnowboardingCircle = SFSymbol(
         title: "figure.snowboarding.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7470,7 +7470,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureSocialdanceCircle = SFSymbol(
         title: "figure.socialdance.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7492,7 +7492,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureSoftballCircle = SFSymbol(
         title: "figure.softball.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7514,7 +7514,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureSquashCircle = SFSymbol(
         title: "figure.squash.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7536,7 +7536,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureStairStepperCircle = SFSymbol(
         title: "figure.stair.stepper.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7558,7 +7558,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureStairsCircle = SFSymbol(
         title: "figure.stairs.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7602,7 +7602,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureStepTrainingCircle = SFSymbol(
         title: "figure.step.training.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7624,7 +7624,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureStrengthtrainingFunctionalCircle = SFSymbol(
         title: "figure.strengthtraining.functional.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7646,7 +7646,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureStrengthtrainingTraditionalCircle = SFSymbol(
         title: "figure.strengthtraining.traditional.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7668,7 +7668,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureSurfingCircle = SFSymbol(
         title: "figure.surfing.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7690,7 +7690,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureTableTennisCircle = SFSymbol(
         title: "figure.table.tennis.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7712,7 +7712,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureTaichiCircle = SFSymbol(
         title: "figure.taichi.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7734,7 +7734,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureTennisCircle = SFSymbol(
         title: "figure.tennis.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7756,7 +7756,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureTrackAndFieldCircle = SFSymbol(
         title: "figure.track.and.field.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7778,7 +7778,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureVolleyballCircle = SFSymbol(
         title: "figure.volleyball.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7811,7 +7811,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureWalkTreadmillCircle = SFSymbol(
         title: "figure.walk.treadmill.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "indoor walk", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7855,7 +7855,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureWaterFitnessCircle = SFSymbol(
         title: "figure.water.fitness.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports", "water"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7877,7 +7877,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureWaterpoloCircle = SFSymbol(
         title: "figure.waterpolo.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports", "water"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7899,7 +7899,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureWrestlingCircle = SFSymbol(
         title: "figure.wrestling.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7921,7 +7921,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureYogaCircle = SFSymbol(
         title: "figure.yoga.circle",
-        categories: [.fitness, .human, .variable],
+        categories: [.fitness, .human, .variable, .draw],
         searchTerms: ["human", "person", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -7987,7 +7987,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let flagPatternCheckeredCircle = SFSymbol(
         title: "flag.pattern.checkered.circle",
-        categories: [.fitness, .gaming, .objectsAndTools, .variable],
+        categories: [.fitness, .gaming, .objectsAndTools, .variable, .draw],
         searchTerms: ["campground", "camping"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -8009,7 +8009,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let florinsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "florinsign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -8064,7 +8064,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let florinsignRing = SFSymbol(
         title: "florinsign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -8130,7 +8130,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let francsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "francsign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -8185,7 +8185,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let francsignRing = SFSymbol(
         title: "francsign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -8218,7 +8218,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let gamecontrollerCircle = SFSymbol(
         title: "gamecontroller.circle",
-        categories: [.devices, .fitness, .gaming, .objectsAndTools, .variable],
+        categories: [.devices, .fitness, .gaming, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -8251,7 +8251,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let gearshapeArrowTrianglehead2ClockwiseRotate90 = SFSymbol(
         title: "gearshape.arrow.trianglehead.2.clockwise.rotate.90",
-        categories: [.arrows],
+        categories: [.arrows, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -8273,7 +8273,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let greaterthanorequaltoCircle = SFSymbol(
         title: "greaterthanorequalto.circle",
-        categories: [.math, .variable],
+        categories: [.math, .variable, .draw],
         searchTerms: [">", "≥"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -8295,7 +8295,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let greaterthanorequaltoSquare = SFSymbol(
         title: "greaterthanorequalto.square",
-        categories: [.math],
+        categories: [.math, .draw],
         searchTerms: [">", "≥"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -8317,7 +8317,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let guaranisignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "guaranisign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -8372,7 +8372,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let guaranisignRing = SFSymbol(
         title: "guaranisign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -8515,7 +8515,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let handRaysFill = SFSymbol(
         title: "hand.rays.fill",
-        categories: [.accessibility, .human],
+        categories: [.accessibility, .human, .draw],
         searchTerms: ["touch"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -8583,7 +8583,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let headphonesSlash = SFSymbol(
         title: "headphones.slash",
-        categories: [.devices, .objectsAndTools],
+        categories: [.devices, .objectsAndTools, .draw],
         searchTerms: ["audio", "sound", "speaker"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -8605,7 +8605,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let headsetCircle = SFSymbol(
         title: "headset.circle",
-        categories: [.automotive, .devices, .objectsAndTools, .variable],
+        categories: [.automotive, .devices, .objectsAndTools, .variable, .draw],
         searchTerms: ["concierge", "road assistance"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -9367,7 +9367,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let houseSlash = SFSymbol(
         title: "house.slash",
-        categories: [.gaming, .home],
+        categories: [.gaming, .home, .draw],
         searchTerms: ["home", "house"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -9378,7 +9378,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let houseSlashFill = SFSymbol(
         title: "house.slash.fill",
-        categories: [.gaming, .home],
+        categories: [.gaming, .home, .draw],
         searchTerms: ["home", "house"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -9389,7 +9389,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let hryvniasignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "hryvniasign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -9444,7 +9444,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let hryvniasignRing = SFSymbol(
         title: "hryvniasign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -9466,7 +9466,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let indianrupeesignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "indianrupeesign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -9521,7 +9521,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let indianrupeesignRing = SFSymbol(
         title: "indianrupeesign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -11117,7 +11117,7 @@ public extension SFSymbol {
     /// - Localizations: Right-to-Left
     static let keyCarRadiowavesForwardFill = SFSymbol(
         title: "key.car.radiowaves.forward.fill",
-        categories: [.automotive, .objectsAndTools, .variable],
+        categories: [.automotive, .objectsAndTools, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical],
@@ -11151,7 +11151,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let kipsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "kipsign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -11206,7 +11206,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let kipsignRing = SFSymbol(
         title: "kipsign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -11228,7 +11228,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let ladybugSlash = SFSymbol(
         title: "ladybug.slash",
-        categories: [.nature],
+        categories: [.nature, .draw],
         searchTerms: ["animals", "bug"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -11239,7 +11239,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let ladybugSlashCircle = SFSymbol(
         title: "ladybug.slash.circle",
-        categories: [.nature, .variable],
+        categories: [.nature, .variable, .draw],
         searchTerms: ["animals", "bug"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -11272,7 +11272,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let larisignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "larisign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -11327,7 +11327,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let larisignRing = SFSymbol(
         title: "larisign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -11349,7 +11349,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let leafArrowTriangleheadClockwise = SFSymbol(
         title: "leaf.arrow.trianglehead.clockwise",
-        categories: [.arrows, .multicolor, .nature],
+        categories: [.arrows, .multicolor, .nature, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -11371,7 +11371,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let lessthanorequaltoCircle = SFSymbol(
         title: "lessthanorequalto.circle",
-        categories: [.math, .variable],
+        categories: [.math, .variable, .draw],
         searchTerms: ["<", "≤"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -11393,7 +11393,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let lessthanorequaltoSquare = SFSymbol(
         title: "lessthanorequalto.square",
-        categories: [.math],
+        categories: [.math, .draw],
         searchTerms: ["<", "≤"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -11415,7 +11415,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let lirasignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "lirasign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -11470,7 +11470,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let lirasignRing = SFSymbol(
         title: "lirasign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -11597,7 +11597,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let malaysianringgitsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "malaysianringgitsign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -11630,7 +11630,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let malaysianringgitsignCircle = SFSymbol(
         title: "malaysianringgitsign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -11674,7 +11674,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let malaysianringgitsignRing = SFSymbol(
         title: "malaysianringgitsign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -11696,7 +11696,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let malaysianringgitsignSquare = SFSymbol(
         title: "malaysianringgitsign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -11718,7 +11718,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let manatsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "manatsign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -11773,7 +11773,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let manatsignRing = SFSymbol(
         title: "manatsign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -11918,7 +11918,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let microphoneCircle = SFSymbol(
         title: "microphone.circle",
-        categories: [.communication, .multicolor, .variable],
+        categories: [.communication, .multicolor, .variable, .draw],
         searchTerms: ["dictate", "dictation"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -11951,7 +11951,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let microphoneSlash = SFSymbol(
         title: "microphone.slash",
-        categories: [.communication, .multicolor],
+        categories: [.communication, .multicolor, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -11962,7 +11962,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let microphoneSlashCircle = SFSymbol(
         title: "microphone.slash.circle",
-        categories: [.communication, .multicolor, .variable],
+        categories: [.communication, .multicolor, .variable, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -11984,7 +11984,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let microphoneSlashFill = SFSymbol(
         title: "microphone.slash.fill",
-        categories: [.communication, .multicolor],
+        categories: [.communication, .multicolor, .draw],
         searchTerms: ["remove"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -11995,7 +11995,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let microphoneSquare = SFSymbol(
         title: "microphone.square",
-        categories: [.communication, .multicolor],
+        categories: [.communication, .multicolor, .draw],
         searchTerms: ["dictate", "dictation"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -12017,7 +12017,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let millsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "millsign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12072,7 +12072,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let millsignRing = SFSymbol(
         title: "millsign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12094,7 +12094,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let minusArrowTriangleheadCounterclockwise = SFSymbol(
         title: "minus.arrow.trianglehead.counterclockwise",
-        categories: [.arrows, .media],
+        categories: [.arrows, .media, .draw],
         searchTerms: ["-"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12193,7 +12193,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let nairasignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "nairasign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12248,7 +12248,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let nairasignRing = SFSymbol(
         title: "nairasign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12270,7 +12270,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let norwegiankronesignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "norwegiankronesign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12325,7 +12325,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let norwegiankronesignRing = SFSymbol(
         title: "norwegiankronesign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12358,7 +12358,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let notequalCircle = SFSymbol(
         title: "notequal.circle",
-        categories: [.math, .variable],
+        categories: [.math, .variable, .draw],
         searchTerms: ["≠"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12380,7 +12380,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let notequalSquare = SFSymbol(
         title: "notequal.square",
-        categories: [.math],
+        categories: [.math, .draw],
         searchTerms: ["≠"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12416,7 +12416,7 @@ public extension SFSymbol {
     /// - Localizations: Arabic, Hindi
     static let numbersRectangle = SFSymbol(
         title: "numbers.rectangle",
-        categories: [.textFormatting],
+        categories: [.textFormatting, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical],
@@ -12441,7 +12441,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let oar2CrossedCircle = SFSymbol(
         title: "oar.2.crossed.circle",
-        categories: [.fitness, .objectsAndTools, .variable],
+        categories: [.fitness, .objectsAndTools, .variable, .draw],
         searchTerms: ["paddling", "sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12507,7 +12507,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let parkingsignSquare = SFSymbol(
         title: "parkingsign.square",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12529,7 +12529,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let person2ArrowTriangleheadCounterclockwise = SFSymbol(
         title: "person.2.arrow.trianglehead.counterclockwise",
-        categories: [.arrows, .human],
+        categories: [.arrows, .human, .draw],
         searchTerms: ["people", "shared"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12661,7 +12661,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let personFillAndArrowLeftAndArrowRightOutward = SFSymbol(
         title: "person.fill.and.arrow.left.and.arrow.right.outward",
-        categories: [.human],
+        categories: [.human, .draw],
         searchTerms: ["people", "user"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12672,7 +12672,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let personalhotspotSlash = SFSymbol(
         title: "personalhotspot.slash",
-        categories: [.connectivity, .objectsAndTools],
+        categories: [.connectivity, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12694,7 +12694,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let peruviansolessignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "peruviansolessign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12727,7 +12727,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let peruviansolessignCircle = SFSymbol(
         title: "peruviansolessign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12771,7 +12771,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let peruviansolessignRing = SFSymbol(
         title: "peruviansolessign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12793,7 +12793,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let peruviansolessignSquare = SFSymbol(
         title: "peruviansolessign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12815,7 +12815,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pesetasignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "pesetasign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12870,7 +12870,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pesetasignRing = SFSymbol(
         title: "pesetasign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12892,7 +12892,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pesosignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "pesosign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -12947,7 +12947,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pesosignRing = SFSymbol(
         title: "pesosign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -13024,7 +13024,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let plusArrowTriangleheadClockwise = SFSymbol(
         title: "plus.arrow.trianglehead.clockwise",
-        categories: [.arrows, .media],
+        categories: [.arrows, .media, .draw],
         searchTerms: ["+", "add"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -13046,7 +13046,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pointBottomleftForwardToArrowTriangleScurvepathFill = SFSymbol(
         title: "point.bottomleft.forward.to.arrow.triangle.scurvepath.fill",
-        categories: [.maps],
+        categories: [.maps, .draw],
         searchTerms: ["activities", "out and back", "path", "switchback", "trail"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -13101,7 +13101,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pointToprightArrowTriangleBackwardToPointBottomleftScurvepathFill = SFSymbol(
         title: "point.topright.arrow.triangle.backward.to.point.bottomleft.scurvepath.fill",
-        categories: [.maps],
+        categories: [.maps, .draw],
         searchTerms: ["activities", "out and back", "path", "switchback", "trail"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -13123,7 +13123,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let polishzlotysignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "polishzlotysign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -13178,7 +13178,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let polishzlotysignRing = SFSymbol(
         title: "polishzlotysign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -13430,7 +13430,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rublesignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "rublesign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -13485,7 +13485,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rublesignRing = SFSymbol(
         title: "rublesign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -13518,7 +13518,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rugbyballCircle = SFSymbol(
         title: "rugbyball.circle",
-        categories: [.fitness, .objectsAndTools, .variable],
+        categories: [.fitness, .objectsAndTools, .variable, .draw],
         searchTerms: ["sports"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -13551,7 +13551,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rupeesignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "rupeesign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -13606,7 +13606,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let rupeesignRing = SFSymbol(
         title: "rupeesign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -13642,7 +13642,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Shared With You feature.
     static let sharedwithyouCircle = SFSymbol(
         title: "sharedwithyou.circle",
-        categories: [.human, .variable],
+        categories: [.human, .variable, .draw],
         searchTerms: ["people", "person"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical],
@@ -13680,7 +13680,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let shekelsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "shekelsign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -13735,7 +13735,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let shekelsignRing = SFSymbol(
         title: "shekelsign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -13779,7 +13779,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let singaporedollarsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "singaporedollarsign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -13812,7 +13812,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let singaporedollarsignCircle = SFSymbol(
         title: "singaporedollarsign.circle",
-        categories: [.commerce, .indices, .variable],
+        categories: [.commerce, .indices, .variable, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -13856,7 +13856,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let singaporedollarsignRing = SFSymbol(
         title: "singaporedollarsign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -13878,7 +13878,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let singaporedollarsignSquare = SFSymbol(
         title: "singaporedollarsign.square",
-        categories: [.commerce, .indices],
+        categories: [.commerce, .indices, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -14010,7 +14010,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sterlingsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "sterlingsign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -14065,7 +14065,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sterlingsignRing = SFSymbol(
         title: "sterlingsign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -14153,7 +14153,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let suvSideHillDescentControlFill = SFSymbol(
         title: "suv.side.hill.descent.control.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: ["DSR"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -14230,7 +14230,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let swedishkronasignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "swedishkronasign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -14285,7 +14285,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let swedishkronasignRing = SFSymbol(
         title: "swedishkronasign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -14318,7 +14318,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tengesignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "tengesign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -14373,7 +14373,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tengesignRing = SFSymbol(
         title: "tengesign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -14432,7 +14432,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, multicolor
     static let textDocumentFill = SFSymbol(
         title: "text.document.fill",
-        categories: [.multicolor, .objectsAndTools],
+        categories: [.multicolor, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .multicolor]
@@ -14476,7 +14476,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let textPageFill = SFSymbol(
         title: "text.page.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: ["reader"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -14807,7 +14807,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let truckSideHillDescentControlFill = SFSymbol(
         title: "truck.side.hill.descent.control.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: ["DSR"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -14873,7 +14873,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tsaCircle = SFSymbol(
         title: "tsa.circle",
-        categories: [.automotive, .variable],
+        categories: [.automotive, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -14895,7 +14895,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tsaSlash = SFSymbol(
         title: "tsa.slash",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -14906,7 +14906,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tugriksignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "tugriksign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -14961,7 +14961,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let tugriksignRing = SFSymbol(
         title: "tugriksign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -14983,7 +14983,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let turkishlirasignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "turkishlirasign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -15038,7 +15038,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let turkishlirasignRing = SFSymbol(
         title: "turkishlirasign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -15152,7 +15152,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple Vision Pro.
     static let visionProCircle = SFSymbol(
         title: "vision.pro.circle",
-        categories: [.devices, .variable],
+        categories: [.devices, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical],
@@ -15204,7 +15204,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple Vision Pro.
     static let visionProSlashCircle = SFSymbol(
         title: "vision.pro.slash.circle",
-        categories: [.devices, .variable],
+        categories: [.devices, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical],
@@ -15230,7 +15230,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple Vision Pro.
     static let visionProSlashFill = SFSymbol(
         title: "vision.pro.slash.fill",
-        categories: [.devices],
+        categories: [.devices, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical],
@@ -15378,7 +15378,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let wave3DownCircle = SFSymbol(
         title: "wave.3.down.circle",
-        categories: [.connectivity, .variable],
+        categories: [.connectivity, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -15389,7 +15389,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let wave3DownCircleFill = SFSymbol(
         title: "wave.3.down.circle.fill",
-        categories: [.connectivity, .multicolor, .variable],
+        categories: [.connectivity, .multicolor, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -15477,7 +15477,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let wave3UpCircle = SFSymbol(
         title: "wave.3.up.circle",
-        categories: [.connectivity, .variable],
+        categories: [.connectivity, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -15488,7 +15488,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let wave3UpCircleFill = SFSymbol(
         title: "wave.3.up.circle.fill",
-        categories: [.connectivity, .multicolor, .variable],
+        categories: [.connectivity, .multicolor, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -15609,7 +15609,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let wonsignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "wonsign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -15664,7 +15664,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let wonsignRing = SFSymbol(
         title: "wonsign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -15708,7 +15708,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let yensignArrowTriangleheadCounterclockwiseRotate90 = SFSymbol(
         title: "yensign.arrow.trianglehead.counterclockwise.rotate.90",
-        categories: [.arrows, .commerce],
+        categories: [.arrows, .commerce, .draw],
         searchTerms: ["currencies", "currency"],
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]
@@ -15763,7 +15763,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let yensignRing = SFSymbol(
         title: "yensign.ring",
-        categories: [.commerce, .home],
+        categories: [.commerce, .home, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.0, macOS: 15.0, tvOS: 18.0, watchOS: 11.0, visionOS: 2.0),
         layersets: [.monochrome, .hierarchical]

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables18P1.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables18P1.swift
@@ -35,7 +35,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cableConnectorVideo = SFSymbol(
         title: "cable.connector.video",
-        categories: [.devices],
+        categories: [.devices, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.1, macOS: 15.1, tvOS: 18.1, watchOS: 11.1, visionOS: 2.1),
         layersets: [.monochrome, .hierarchical]
@@ -248,7 +248,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let handThumbsdownSlash = SFSymbol(
         title: "hand.thumbsdown.slash",
-        categories: [.human],
+        categories: [.human, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.1, macOS: 15.1, tvOS: 18.1, watchOS: 11.1, visionOS: 2.1),
         layersets: [.monochrome, .hierarchical]
@@ -259,7 +259,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let handThumbsdownSlashFill = SFSymbol(
         title: "hand.thumbsdown.slash.fill",
-        categories: [.human],
+        categories: [.human, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.1, macOS: 15.1, tvOS: 18.1, watchOS: 11.1, visionOS: 2.1),
         layersets: [.monochrome, .hierarchical]
@@ -270,7 +270,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let handThumbsupSlash = SFSymbol(
         title: "hand.thumbsup.slash",
-        categories: [.human],
+        categories: [.human, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.1, macOS: 15.1, tvOS: 18.1, watchOS: 11.1, visionOS: 2.1),
         layersets: [.monochrome, .hierarchical]
@@ -281,7 +281,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let handThumbsupSlashFill = SFSymbol(
         title: "hand.thumbsup.slash.fill",
-        categories: [.human],
+        categories: [.human, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.1, macOS: 15.1, tvOS: 18.1, watchOS: 11.1, visionOS: 2.1),
         layersets: [.monochrome, .hierarchical]

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables18P2.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables18P2.swift
@@ -172,7 +172,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let insetFilledRectangleAndPersonFilledCircle = SFSymbol(
         title: "inset.filled.rectangle.and.person.filled.circle",
-        categories: [.human, .variable],
+        categories: [.human, .variable, .draw],
         searchTerms: ["people", "screen sharing"],
         releaseInfo: ReleaseInfo(iOS: 18.2, macOS: 15.2, tvOS: 18.2, watchOS: 11.2, visionOS: 2.2),
         layersets: [.monochrome, .hierarchical]
@@ -227,7 +227,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let wandAndOutlineInverse = SFSymbol(
         title: "wand.and.outline.inverse",
-        categories: [.editing, .objectsAndTools],
+        categories: [.editing, .objectsAndTools, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.2, macOS: 15.2, tvOS: 18.2, watchOS: 11.2, visionOS: 2.2),
         layersets: [.monochrome, .hierarchical]

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables18P4.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables18P4.swift
@@ -46,7 +46,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let carSideArrowLeftAndRightFill = SFSymbol(
         title: "car.side.arrow.left.and.right.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.4, macOS: 15.4, tvOS: 18.4, watchOS: 11.4, visionOS: 2.4),
         layersets: [.monochrome, .hierarchical]
@@ -68,7 +68,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let carSideHillDownAndGaugeOpenWithLinesNeedle25PercentAndArrowtriangleFill = SFSymbol(
         title: "car.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.4, macOS: 15.4, tvOS: 18.4, watchOS: 11.4, visionOS: 2.4),
         layersets: [.monochrome, .hierarchical]
@@ -257,7 +257,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let convertibleSideArrowLeftAndRightFill = SFSymbol(
         title: "convertible.side.arrow.left.and.right.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.4, macOS: 15.4, tvOS: 18.4, watchOS: 11.4, visionOS: 2.4),
         layersets: [.monochrome, .hierarchical]
@@ -279,7 +279,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let convertibleSideHillDownAndGaugeOpenWithLinesNeedle25PercentAndArrowtriangleFill = SFSymbol(
         title: "convertible.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.4, macOS: 15.4, tvOS: 18.4, watchOS: 11.4, visionOS: 2.4),
         layersets: [.monochrome, .hierarchical]
@@ -402,7 +402,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let envelopeAndArrow3DownFill = SFSymbol(
         title: "envelope.and.arrow.3.down.fill",
-        categories: nil,
+        categories: [.draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.4, macOS: 15.4, tvOS: 18.4, watchOS: 11.4, visionOS: 2.4),
         layersets: [.monochrome, .hierarchical]
@@ -446,7 +446,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let hydrogenCircle = SFSymbol(
         title: "hydrogen.circle",
-        categories: [.automotive, .variable],
+        categories: [.automotive, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.4, macOS: 15.4, tvOS: 18.4, watchOS: 11.4, visionOS: 2.4),
         layersets: [.monochrome, .hierarchical]
@@ -468,7 +468,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let hydrogenSquare = SFSymbol(
         title: "hydrogen.square",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.4, macOS: 15.4, tvOS: 18.4, watchOS: 11.4, visionOS: 2.4),
         layersets: [.monochrome, .hierarchical]
@@ -847,7 +847,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let piCircle = SFSymbol(
         title: "pi.circle",
-        categories: [.math, .variable],
+        categories: [.math, .variable, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.4, macOS: 15.4, tvOS: 18.4, watchOS: 11.4, visionOS: 2.4),
         layersets: [.monochrome, .hierarchical]
@@ -869,7 +869,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let piSquare = SFSymbol(
         title: "pi.square",
-        categories: [.math],
+        categories: [.math, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.4, macOS: 15.4, tvOS: 18.4, watchOS: 11.4, visionOS: 2.4),
         layersets: [.monochrome, .hierarchical]
@@ -902,7 +902,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let plusMinusCapsuleFill = SFSymbol(
         title: "plus.minus.capsule.fill",
-        categories: [.multicolor],
+        categories: [.multicolor, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.4, macOS: 15.4, tvOS: 18.4, watchOS: 11.4, visionOS: 2.4),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1080,7 +1080,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let suvSideArrowLeftAndRightFill = SFSymbol(
         title: "suv.side.arrow.left.and.right.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.4, macOS: 15.4, tvOS: 18.4, watchOS: 11.4, visionOS: 2.4),
         layersets: [.monochrome, .hierarchical]
@@ -1102,7 +1102,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let suvSideHillDownAndGaugeOpenWithLinesNeedle25PercentAndArrowtriangleFill = SFSymbol(
         title: "suv.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.4, macOS: 15.4, tvOS: 18.4, watchOS: 11.4, visionOS: 2.4),
         layersets: [.monochrome, .hierarchical]
@@ -1278,7 +1278,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let truckPickupSideArrowLeftAndRightFill = SFSymbol(
         title: "truck.pickup.side.arrow.left.and.right.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.4, macOS: 15.4, tvOS: 18.4, watchOS: 11.4, visionOS: 2.4),
         layersets: [.monochrome, .hierarchical]
@@ -1300,7 +1300,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let truckPickupSideHillDownAndGaugeOpenWithLinesNeedle25PercentAndArrowtriangleFill = SFSymbol(
         title: "truck.pickup.side.hill.down.and.gauge.open.with.lines.needle.25percent.and.arrowtriangle.fill",
-        categories: [.automotive],
+        categories: [.automotive, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 18.4, macOS: 15.4, tvOS: 18.4, watchOS: 11.4, visionOS: 2.4),
         layersets: [.monochrome, .hierarchical]

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables26.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables26.swift
@@ -913,7 +913,7 @@ public extension SFSymbol {
     /// - Localizations: Right-to-Left
     static let arrowForwardFolderFill = SFSymbol(
         title: "arrow.forward.folder.fill",
-        categories: [.multicolor, .objectsAndTools, .whatsNew],
+        categories: [.multicolor, .objectsAndTools, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical, .multicolor],
@@ -969,7 +969,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let backpackSensorTagRadiowavesLeftAndRightFill = SFSymbol(
         title: "backpack.sensor.tag.radiowaves.left.and.right.fill",
-        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew],
+        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1002,7 +1002,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let bellBadgeWaveformSlash = SFSymbol(
         title: "bell.badge.waveform.slash",
-        categories: [.objectsAndTools, .whatsNew],
+        categories: [.objectsAndTools, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -1013,7 +1013,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let bellBadgeWaveformSlashFill = SFSymbol(
         title: "bell.badge.waveform.slash.fill",
-        categories: [.objectsAndTools, .whatsNew],
+        categories: [.objectsAndTools, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -1035,7 +1035,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let bicycleSensorTagRadiowavesLeftAndRightFill = SFSymbol(
         title: "bicycle.sensor.tag.radiowaves.left.and.right.fill",
-        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew],
+        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1123,7 +1123,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let briefcaseSensorTagRadiowavesLeftAndRightFill = SFSymbol(
         title: "briefcase.sensor.tag.radiowaves.left.and.right.fill",
-        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew],
+        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1156,7 +1156,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let calendarDayTimelineLeadingCircle = SFSymbol(
         title: "calendar.day.timeline.leading.circle",
-        categories: [.variable, .whatsNew],
+        categories: [.variable, .whatsNew, .draw],
         searchTerms: ["date"],
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -1178,7 +1178,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let calendarDayTimelineLeftCircle = SFSymbol(
         title: "calendar.day.timeline.left.circle",
-        categories: [.variable, .whatsNew],
+        categories: [.variable, .whatsNew, .draw],
         searchTerms: ["date"],
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -1200,7 +1200,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let calendarDayTimelineRightCircle = SFSymbol(
         title: "calendar.day.timeline.right.circle",
-        categories: [.variable, .whatsNew],
+        categories: [.variable, .whatsNew, .draw],
         searchTerms: ["date"],
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -1222,7 +1222,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let calendarDayTimelineTrailingCircle = SFSymbol(
         title: "calendar.day.timeline.trailing.circle",
-        categories: [.variable, .whatsNew],
+        categories: [.variable, .whatsNew, .draw],
         searchTerms: ["date"],
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -1255,7 +1255,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let cameraSensorTagRadiowavesLeftAndRightFill = SFSymbol(
         title: "camera.sensor.tag.radiowaves.left.and.right.fill",
-        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew],
+        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1299,7 +1299,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cellularbarsCircle = SFSymbol(
         title: "cellularbars.circle",
-        categories: [.connectivity, .variable, .whatsNew],
+        categories: [.connectivity, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -1310,7 +1310,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let cellularbarsCircleFill = SFSymbol(
         title: "cellularbars.circle.fill",
-        categories: [.connectivity, .multicolor, .variable, .whatsNew],
+        categories: [.connectivity, .multicolor, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1455,7 +1455,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let checkmarkApp = SFSymbol(
         title: "checkmark.app",
-        categories: [.whatsNew],
+        categories: [.whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -1466,7 +1466,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let checkmarkAppFill = SFSymbol(
         title: "checkmark.app.fill",
-        categories: [.multicolor, .whatsNew],
+        categories: [.multicolor, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -1477,7 +1477,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let checkmarkArrowTriangleheadClockwise = SFSymbol(
         title: "checkmark.arrow.trianglehead.clockwise",
-        categories: [.whatsNew],
+        categories: [.whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -1532,7 +1532,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let checkmarkCircleDotted = SFSymbol(
         title: "checkmark.circle.dotted",
-        categories: [.privacyAndSecurity, .whatsNew],
+        categories: [.privacyAndSecurity, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -1631,7 +1631,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let coatCircle = SFSymbol(
         title: "coat.circle",
-        categories: [.variable, .whatsNew],
+        categories: [.variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -1675,7 +1675,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let creditcardArrowTrianglehead2ClockwiseRotate90 = SFSymbol(
         title: "creditcard.arrow.trianglehead.2.clockwise.rotate.90",
-        categories: [.commerce, .objectsAndTools, .whatsNew],
+        categories: [.commerce, .objectsAndTools, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -1708,7 +1708,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let cubeCircle = SFSymbol(
         title: "cube.circle",
-        categories: [.objectsAndTools, .variable, .whatsNew],
+        categories: [.objectsAndTools, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -2063,7 +2063,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Environments feature.
     static let environmentsCircle = SFSymbol(
         title: "environments.circle",
-        categories: [.nature, .variable, .whatsNew],
+        categories: [.nature, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical],
@@ -2115,7 +2115,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Environments feature.
     static let environmentsSlashCircle = SFSymbol(
         title: "environments.slash.circle",
-        categories: [.nature, .variable, .whatsNew],
+        categories: [.nature, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical],
@@ -2175,7 +2175,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let eraserSlash = SFSymbol(
         title: "eraser.slash",
-        categories: [.whatsNew],
+        categories: [.whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -2186,7 +2186,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let eraserSlashFill = SFSymbol(
         title: "eraser.slash.fill",
-        categories: [.whatsNew],
+        categories: [.whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -2241,7 +2241,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let fCursiveSlash = SFSymbol(
         title: "f.cursive.slash",
-        categories: [.cameraAndPhotos, .whatsNew],
+        categories: [.cameraAndPhotos, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -2274,7 +2274,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let fanCircle = SFSymbol(
         title: "fan.circle",
-        categories: [.automotive, .home, .objectsAndTools, .variable, .whatsNew],
+        categories: [.automotive, .home, .objectsAndTools, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -2395,7 +2395,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let figureWalkSuitcaseRollingCircle = SFSymbol(
         title: "figure.walk.suitcase.rolling.circle",
-        categories: [.human, .maps, .transportation, .variable, .whatsNew],
+        categories: [.human, .maps, .transportation, .variable, .whatsNew, .draw],
         searchTerms: ["gate", "human", "person", "walking"],
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -2674,7 +2674,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let handbagSensorTagRadiowavesLeftAndRightFill = SFSymbol(
         title: "handbag.sensor.tag.radiowaves.left.and.right.fill",
-        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew],
+        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -2707,7 +2707,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let headphonesSensorTagRadiowavesLeftAndRightFill = SFSymbol(
         title: "headphones.sensor.tag.radiowaves.left.and.right.fill",
-        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew],
+        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -2773,7 +2773,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let heatWavesCircle = SFSymbol(
         title: "heat.waves.circle",
-        categories: [.arrows, .automotive, .variable, .whatsNew],
+        categories: [.arrows, .automotive, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -3247,7 +3247,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let jacketCircle = SFSymbol(
         title: "jacket.circle",
-        categories: [.variable, .whatsNew],
+        categories: [.variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -3280,7 +3280,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let jacketSensorTagRadiowavesLeftAndRightFill = SFSymbol(
         title: "jacket.sensor.tag.radiowaves.left.and.right.fill",
-        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew],
+        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -3291,7 +3291,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let keyCircle = SFSymbol(
         title: "key.circle",
-        categories: [.automotive, .objectsAndTools, .privacyAndSecurity, .variable, .whatsNew],
+        categories: [.automotive, .objectsAndTools, .privacyAndSecurity, .variable, .whatsNew, .draw],
         searchTerms: ["password", "security"],
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -3324,7 +3324,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let keySensorTagRadiowavesLeftAndRightFill = SFSymbol(
         title: "key.sensor.tag.radiowaves.left.and.right.fill",
-        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew],
+        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -3423,7 +3423,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let listDashHeaderRectangleFill = SFSymbol(
         title: "list.dash.header.rectangle.fill",
-        categories: [.multicolor, .whatsNew],
+        categories: [.multicolor, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -3741,7 +3741,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let minusArrowTriangleheadClockwise = SFSymbol(
         title: "minus.arrow.trianglehead.clockwise",
-        categories: [.whatsNew],
+        categories: [.whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -3763,7 +3763,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let musicNoteArrowTriangleheadClockwise = SFSymbol(
         title: "music.note.arrow.trianglehead.clockwise",
-        categories: [.arrows, .whatsNew],
+        categories: [.arrows, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -3774,7 +3774,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let musicNoteSlash = SFSymbol(
         title: "music.note.slash",
-        categories: [.whatsNew],
+        categories: [.whatsNew, .draw],
         searchTerms: ["media"],
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -4046,7 +4046,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let petCarrierCircle = SFSymbol(
         title: "pet.carrier.circle",
-        categories: [.objectsAndTools, .variable, .whatsNew],
+        categories: [.objectsAndTools, .variable, .whatsNew, .draw],
         searchTerms: ["luggage"],
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -4090,7 +4090,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let phonePauseCircle = SFSymbol(
         title: "phone.pause.circle",
-        categories: [.communication, .media, .variable, .whatsNew],
+        categories: [.communication, .media, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -4145,7 +4145,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let plusArrowTriangleheadCounterclockwise = SFSymbol(
         title: "plus.arrow.trianglehead.counterclockwise",
-        categories: [.arrows, .media, .whatsNew],
+        categories: [.arrows, .media, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -4156,7 +4156,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let plusCapsule = SFSymbol(
         title: "plus.capsule",
-        categories: [.whatsNew],
+        categories: [.whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -4167,7 +4167,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let plusCapsuleFill = SFSymbol(
         title: "plus.capsule.fill",
-        categories: [.multicolor, .whatsNew],
+        categories: [.multicolor, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -4266,7 +4266,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pointerArrowIpadSlash = SFSymbol(
         title: "pointer.arrow.ipad.slash",
-        categories: [.whatsNew],
+        categories: [.whatsNew, .draw],
         searchTerms: ["cursor"],
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -4277,7 +4277,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pointerArrowIpadSlashSquare = SFSymbol(
         title: "pointer.arrow.ipad.slash.square",
-        categories: [.whatsNew],
+        categories: [.whatsNew, .draw],
         searchTerms: ["cursor"],
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -4299,7 +4299,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pointerArrowIpadSquare = SFSymbol(
         title: "pointer.arrow.ipad.square",
-        categories: [.whatsNew],
+        categories: [.whatsNew, .draw],
         searchTerms: ["cursor"],
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -4354,7 +4354,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pointerArrowSlash = SFSymbol(
         title: "pointer.arrow.slash",
-        categories: nil,
+        categories: [.draw],
         searchTerms: ["cursor"],
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -4365,7 +4365,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pointerArrowSlashSquare = SFSymbol(
         title: "pointer.arrow.slash.square",
-        categories: nil,
+        categories: [.draw],
         searchTerms: ["cursor"],
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -4387,7 +4387,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let pointerArrowSquare = SFSymbol(
         title: "pointer.arrow.square",
-        categories: nil,
+        categories: [.draw],
         searchTerms: ["cursor"],
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -4530,7 +4530,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let sensorRadiowavesLeftAndRightFill = SFSymbol(
         title: "sensor.radiowaves.left.and.right.fill",
-        categories: [.devices, .variable, .whatsNew],
+        categories: [.devices, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -4574,7 +4574,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let shoeArrowTriangleheadUpAndDownFill = SFSymbol(
         title: "shoe.arrow.trianglehead.up.and.down.fill",
-        categories: [.automotive, .objectsAndTools, .whatsNew],
+        categories: [.automotive, .objectsAndTools, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -4596,7 +4596,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let shoeArrowTriangleheadUpRightCircle = SFSymbol(
         title: "shoe.arrow.trianglehead.up.right.circle",
-        categories: [.automotive, .objectsAndTools, .variable, .whatsNew],
+        categories: [.automotive, .objectsAndTools, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -4772,7 +4772,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Spatial Scene feature.
     static let spatialCaptureSlash = SFSymbol(
         title: "spatial.capture.slash",
-        categories: [.whatsNew],
+        categories: [.whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical],
@@ -4785,7 +4785,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s Spatial Scene feature.
     static let spatialCaptureSlashFill = SFSymbol(
         title: "spatial.capture.slash.fill",
-        categories: [.whatsNew],
+        categories: [.whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical],
@@ -4852,7 +4852,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let strokeLineDiagonalSlash = SFSymbol(
         title: "stroke.line.diagonal.slash",
-        categories: [.communication, .whatsNew],
+        categories: [.communication, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -4863,7 +4863,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let suitcaseCircle = SFSymbol(
         title: "suitcase.circle",
-        categories: [.variable, .whatsNew],
+        categories: [.variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -4896,7 +4896,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let suitcaseRollingAndFilmCircle = SFSymbol(
         title: "suitcase.rolling.and.film.circle",
-        categories: [.objectsAndTools, .variable, .whatsNew],
+        categories: [.objectsAndTools, .variable, .whatsNew, .draw],
         searchTerms: ["luggage"],
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -4940,7 +4940,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let suitcaseRollingAndSuitcaseCircle = SFSymbol(
         title: "suitcase.rolling.and.suitcase.circle",
-        categories: [.objectsAndTools, .variable, .whatsNew],
+        categories: [.objectsAndTools, .variable, .whatsNew, .draw],
         searchTerms: ["luggage"],
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -4973,7 +4973,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let suitcaseRollingCircle = SFSymbol(
         title: "suitcase.rolling.circle",
-        categories: [.objectsAndTools, .variable, .whatsNew],
+        categories: [.objectsAndTools, .variable, .whatsNew, .draw],
         searchTerms: ["luggage"],
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -5006,7 +5006,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome
     static let textBelowFolderFill = SFSymbol(
         title: "text.below.folder.fill",
-        categories: [.objectsAndTools, .whatsNew],
+        categories: [.objectsAndTools, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome]
@@ -5179,7 +5179,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let ticketCircle = SFSymbol(
         title: "ticket.circle",
-        categories: [.objectsAndTools, .variable, .whatsNew],
+        categories: [.objectsAndTools, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -5245,7 +5245,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let umbrellaCircle = SFSymbol(
         title: "umbrella.circle",
-        categories: [.objectsAndTools, .variable, .whatsNew],
+        categories: [.objectsAndTools, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical]
@@ -5289,7 +5289,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let umbrellaSensorTagRadiowavesLeftAndRightFill = SFSymbol(
         title: "umbrella.sensor.tag.radiowaves.left.and.right.fill",
-        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew],
+        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical, .multicolor]
@@ -5359,7 +5359,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical, multicolor
     static let walletSensorTagRadiowavesLeftAndRightFill = SFSymbol(
         title: "wallet.sensor.tag.radiowaves.left.and.right.fill",
-        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew],
+        categories: [.devices, .multicolor, .objectsAndTools, .variable, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.0, macOS: 26.0, tvOS: 26.0, watchOS: 26.0, visionOS: 26.0),
         layersets: [.monochrome, .hierarchical, .multicolor]

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables26P1.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables26P1.swift
@@ -24,7 +24,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let airConditionerSlash = SFSymbol(
         title: "air.conditioner.slash",
-        categories: [.automotive, .whatsNew],
+        categories: [.automotive, .whatsNew, .draw],
         searchTerms: nil,
         releaseInfo: ReleaseInfo(iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1),
         layersets: [.monochrome, .hierarchical]
@@ -302,7 +302,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let starRectangle = SFSymbol(
         title: "star.rectangle",
-        categories: [.whatsNew],
+        categories: [.whatsNew, .draw],
         searchTerms: ["favorite"],
         releaseInfo: ReleaseInfo(iOS: 26.1, macOS: 26.1, tvOS: 26.1, watchOS: 26.1, visionOS: 26.1),
         layersets: [.monochrome, .hierarchical]

--- a/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables27.swift
+++ b/Sources/SFSymbols/SFSymbol+StaticVariables/SFSymbol+StaticVariables27.swift
@@ -157,7 +157,7 @@ public extension SFSymbol {
     /// - Warning: This symbol may not be modified and may only be used to refer to Apple’s AirPods Pro.
     static let airpodsProGen3ChargingcaseWirelessRadiowavesLeftAndRightFill = SFSymbol(
         title: "airpods.pro.gen3.chargingcase.wireless.radiowaves.left.and.right.fill",
-        categories: [.devices, .variable, .whatsNew],
+        categories: [.devices, .variable, .whatsNew, .draw],
         searchTerms: ["audio"],
         releaseInfo: ReleaseInfo(iOS: 27.0, macOS: 27.0, tvOS: 27.0, watchOS: 27.0, visionOS: 27.0),
         layersets: [.monochrome, .hierarchical],
@@ -577,7 +577,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let buildingClassicalColumnsCircle = SFSymbol(
         title: "building.classical.columns.circle",
-        categories: [.variable],
+        categories: [.variable, .draw],
         searchTerms: ["library"],
         releaseInfo: ReleaseInfo(iOS: 27.0, macOS: 27.0, tvOS: 27.0, watchOS: 27.0, visionOS: 27.0),
         layersets: [.monochrome, .hierarchical]
@@ -1974,7 +1974,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let microphoneDynamicOnStandCircle = SFSymbol(
         title: "microphone.dynamic.on.stand.circle",
-        categories: [.objectsAndTools, .variable],
+        categories: [.objectsAndTools, .variable, .draw],
         searchTerms: ["microphone"],
         releaseInfo: ReleaseInfo(iOS: 27.0, macOS: 27.0, tvOS: 27.0, watchOS: 27.0, visionOS: 27.0),
         layersets: [.monochrome, .hierarchical]
@@ -2073,7 +2073,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let numberSignCircle = SFSymbol(
         title: "number.sign.circle",
-        categories: [.math, .variable],
+        categories: [.math, .variable, .draw],
         searchTerms: ["#", "hash", "octothorpe", "pound"],
         releaseInfo: ReleaseInfo(iOS: 27.0, macOS: 27.0, tvOS: 27.0, watchOS: 27.0, visionOS: 27.0),
         layersets: [.monochrome, .hierarchical]
@@ -2095,7 +2095,7 @@ public extension SFSymbol {
     /// - Layersets: monochrome, hierarchical
     static let numberSignSquare = SFSymbol(
         title: "number.sign.square",
-        categories: [.math],
+        categories: [.math, .draw],
         searchTerms: ["#", "hash", "octothorpe", "pound"],
         releaseInfo: ReleaseInfo(iOS: 27.0, macOS: 27.0, tvOS: 27.0, watchOS: 27.0, visionOS: 27.0),
         layersets: [.monochrome, .hierarchical]


### PR DESCRIPTION
Applies the complete **Draw** category to the generated symbol sources, regenerated via `sfsym-gen update` against **SF Symbols 8.0 (123)**.

### What changed
- Draw-tagged symbols grow **773 → 2031**.
- The diff is **exclusively** `.draw` additions to `categories:` arrays (+1258/−1258 lines, one per newly-tagged symbol). Nothing else changed — the pipeline is otherwise idempotent.
- Library builds clean.

### How the Draw set was derived
Draw membership is in no metadata file — the app computes it at render time from glyph geometry. The base branch (`feature/draw-support`) adds a turnkey extractor that clones + ad-hoc re-signs the app and drives its own `UnifiedSymbolAnnotation.hasDrawInfo` under lldb to flag every glyph. The 2031 result is a strict superset of the previously hand-captured 773 and was spot-checked in the app.

Base branch (`feature/draw-support`) contains the tooling; this PR contains only the regenerated output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)