### PR TITLE
Auto-extract the Draw category via the app's own hasDrawInfo

### DIFF
--- a/.claude/skills/update-sf-symbols/SKILL.md
+++ b/.claude/skills/update-sf-symbols/SKILL.md
@@ -13,39 +13,47 @@ commands from the repository root.
 - Install the target **SF Symbols Beta app** at `/Applications/SF Symbols Beta.app`.
 - Run on the **latest macOS** — deprecation/restriction data comes from the system
   CoreGlyphs bundle, which is tied to the OS version.
+- **Xcode command-line tools** (`lldb`, `codesign`, `otool`) — required for automatic
+  Draw-category extraction (step 1). Verify with `xcode-select -p`.
 - Confirm the version you're targeting: `defaults read "/Applications/SF Symbols Beta.app/Contents/Info.plist" CFBundleShortVersionString` (and `CFBundleVersion`).
 
-## 1. Capture the Draw category (manual — required)
-Draw membership is **not** in any metadata file; it must be copied from the app.
-Two ways:
-- **Let the pipeline prompt:** in the app, select **Draw** → click a symbol → **⌘A** →
-  **⌘⇧C**, then run step 2 — it reads the clipboard when `draw.txt` is absent.
-- **Or pre-stage `draw.txt`:** write the copied names (one per line) to `draw.txt` in the
-  repo root before step 2.
-
-If you're refreshing an existing release without Draw changes, you can reconstruct the
-prior Draw list from the committed source:
+## 1. Draw category (automatic)
+Draw membership is in **no** metadata file — the app computes it at render time from
+glyph geometry. The pipeline extracts it automatically (step 2 runs it; or run it
+standalone):
 ```bash
-python3 - <<'PY'
-import re, glob
-draw=set()
-for f in glob.glob("Sources/SFSymbols/SFSymbol+StaticVariables/*.swift"):
-    for m in re.finditer(r'title:\s*"([^"]+)"\s*,\s*\n\s*categories:\s*(\[[^\]]*\]|nil)', open(f).read()):
-        if '.draw' in [x.strip() for x in m.group(2).strip('[]').split(',')]: draw.add(m.group(1))
-open("draw.txt","w").write("\n".join(sorted(draw)))
-print("draw.txt", len(draw))
-PY
+swift run --package-path Tools sfsym-gen draw --app "/Applications/SF Symbols Beta.app" --output draw.txt
 ```
-(But brand-new draw symbols in the new release still require the manual capture above.)
+How it works (`Tools/Sources/SFSymbolsGenKit/DrawExtraction.swift`): it clones the app,
+ad-hoc re-signs the copy with `get-task-allow`, then drives the app's own
+`UnifiedSymbolAnnotation.hasDrawInfo` under lldb — calling its draw-check function for
+every glyph. Takes ~2 min with a progress bar. The throwaway app copy **freezes while
+lldb drives it — that's expected**; it's killed when done. It **soft-fails** to a manual
+clipboard prompt (select **Draw** → ⌘A → ⌘⇧C) if anything goes wrong.
+
+**If auto-extraction can't locate the draw-check function** (it moves every app build),
+find it by hand and pass `--draw-func`:
+```bash
+SF="/Applications/SF Symbols Beta.app/Contents/Frameworks/SFSymbolsShared.framework/Versions/A/SFSymbolsShared"
+APP="/Applications/SF Symbols Beta.app/Contents/MacOS/SF Symbols Beta"
+nm "$SF" | grep -i hasDrawInfo | swift demangle          # confirm the getter still exists
+otool -arch arm64 -tV "$APP" | grep -n hasDrawInfoSbvg    # its SOLE caller (the `bl`)
+# → scroll up to the nearest function prologue after a `ret`/`brk`; pass that as:
+#   sfsym-gen update --draw-func 0x…
+```
+If the `hasDrawInfo` getter is renamed/removed entirely, the method needs revisiting
+(it's the anchor for both auto-detection and the disassembly).
 
 ## 2. Run the update
 ```bash
 swift run --package-path Tools sfsym-gen update --app "/Applications/SF Symbols Beta.app"
 ```
-This decrypts use-restrictions from the font, merges CoreGlyphs ∪ app metadata
-(so symbols for an unreleased OS are included), applies Draw + restrictions, writes the
-generated sources, and cleans up temp files. The decrypt step **soft-fails** to
-CoreGlyphs-only restrictions if the private symbol is unavailable.
+This auto-extracts the Draw category (step 1, unless `draw.txt` is already staged),
+decrypts use-restrictions from the font, merges CoreGlyphs ∪ app metadata (so symbols
+for an unreleased OS are included), applies Draw + restrictions, writes the generated
+sources, and cleans up temp files. The decrypt step **soft-fails** to CoreGlyphs-only
+restrictions if the private symbol is unavailable; Draw soft-fails to a manual prompt.
+Pass `--draw-func 0x…` here too if Draw auto-detection needs an override (see step 1).
 
 ## 3. Verify
 ```bash

--- a/Tools/Sources/SFSymbolsGenKit/Decrypt.swift
+++ b/Tools/Sources/SFSymbolsGenKit/Decrypt.swift
@@ -37,6 +37,46 @@ fileprivate func fourCC(_ s: String) -> UInt32 {
     s.utf8.reduce(0) { ($0 << 8) | UInt32($1) }
 }
 
+/// Decrypts the app font's obfuscated `symp` CSV table and returns it as a string.
+/// Returns nil on any failure (missing framework/font, decryptor symbol changed, …).
+/// Shared by the use-restriction and Draw-category extractors.
+func decryptedSympCSV(appPath: String) -> String? {
+    let coreGlyphsLib = URL(fileURLWithPath: appPath)
+        .appendingPathComponent("Contents/Frameworks/SFSymbolsShared.framework/Versions/A/Frameworks/CoreGlyphsLib.framework/Versions/A/CoreGlyphsLib")
+    guard FileManager.default.fileExists(atPath: coreGlyphsLib.path),
+          dlopen(coreGlyphsLib.path, RTLD_NOW) != nil else { return nil }
+
+    let fontURL = URL(fileURLWithPath: appPath)
+        .appendingPathComponent("Contents/Resources/Fonts/SFSymbolsFallback.otf")
+    guard FileManager.default.fileExists(atPath: fontURL.path),
+          let descriptors = CTFontManagerCreateFontDescriptorsFromURL(fontURL as CFURL) as? [CTFontDescriptor],
+          let descriptor = descriptors.first else { return nil }
+    let font = CTFontCreateWithFontDescriptor(descriptor, 12.0, nil)
+
+    guard let sympData = CryptonShim.decryptObfuscatedFontTable(fourCC("symp"), font),
+          let csv = String(data: sympData, encoding: .utf8) else { return nil }
+    return csv
+}
+
+/// Maps every symbol's primary PUA scalar (uppercase hex) to the symbol names that
+/// share it. Used by the Draw-category extractor to turn draw-flagged glyph scalars
+/// back into symbol names. Returns nil if the `symp` table can't be read.
+func loadSympPUAToNames(appPath: String) -> [String: [String]]? {
+    guard let csv = decryptedSympCSV(appPath: appPath) else { return nil }
+    let rows = parseCSV(csv)
+    guard let header = rows.first,
+          let nameIdx = header.firstIndex(of: "Name"),
+          let puaIdx = header.firstIndex(of: "PUAs") else { return nil }
+    var map: [String: [String]] = [:]
+    for row in rows.dropFirst() where row.count > max(nameIdx, puaIdx) {
+        let name = row[nameIdx].trimmingCharacters(in: .whitespacesAndNewlines)
+        let pua = row[puaIdx].trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        guard !name.isEmpty, !pua.isEmpty else { continue }
+        map[pua, default: []].append(name)
+    }
+    return map.isEmpty ? nil : map
+}
+
 // MARK: - Minimal RFC-4180 CSV parser
 
 fileprivate func parseCSV(_ text: String) -> [[String]] {

--- a/Tools/Sources/SFSymbolsGenKit/DrawExtraction.swift
+++ b/Tools/Sources/SFSymbolsGenKit/DrawExtraction.swift
@@ -1,0 +1,316 @@
+import Foundation
+
+//  DrawExtraction.swift
+//
+//  Automatically extracts the SF Symbols "Draw" category — the one piece of
+//  metadata that lives in NO readable file. Draw membership is computed by the
+//  app at render time: it composes each symbol's annotation (merging slash/badge/
+//  base layers) and calls the private getter
+//  `SFSymbolsShared.UnifiedSymbolAnnotation.hasDrawInfo`. That computation needs
+//  the app's live symbol store, so we drive the app's own code:
+//
+//    1. Decrypt the font's `symp` table → every symbol's PUA scalar (Decrypt.swift).
+//    2. Locate the app's draw-check closure — the SOLE caller of `hasDrawInfo`.
+//    3. Clone the app and re-sign it ad-hoc with `get-task-allow` so it's debuggable.
+//    4. Launch it under lldb; on the first render, capture the live symbol-store
+//       context, then call the draw-check function directly for every PUA scalar.
+//    5. Map draw-flagged scalars back to names → write `draw.txt`.
+//
+//  This replaces a manual "open the app, select Draw, ⌘A, ⌘C" clipboard step.
+//  It SOFT-FAILS: any problem returns false and the caller falls back to the
+//  manual prompt. See `.claude/skills/update-sf-symbols/SKILL.md` for the operational
+//  notes (including how to re-derive the draw-check function address after an app update).
+
+// MARK: - Public entry points
+
+/// Standalone Draw-category extraction (used by the `sfsym-gen draw` subcommand and
+/// for debugging). Writes the draw symbol names to `outputPath`. Returns `true` on
+/// success. Uses a temporary working directory that is cleaned up afterward.
+@discardableResult
+public func extractDrawCategory(appPath: String, outputPath: URL, drawFunc: UInt64? = nil) -> Bool {
+    let workingDir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("sfsym-draw-\(ProcessInfo.processInfo.processIdentifier)", isDirectory: true)
+    try? FileManager.default.removeItem(at: workingDir)
+    try? FileManager.default.createDirectory(at: workingDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: workingDir) }
+    return extractDrawCategoryAutomatically(
+        appPath: appPath,
+        drawFilePath: outputPath,
+        drawFuncOverride: drawFunc,
+        workingDir: workingDir
+    )
+}
+
+// MARK: - Internal entry point
+
+/// Extracts the Draw category by driving the app's own `hasDrawInfo` logic and
+/// writes the matching symbol names to `drawFilePath`. Returns `true` on success.
+///
+/// - Parameter drawFuncOverride: file address (vm address, e.g. `0x1000ec6bc`) of
+///   the draw-check closure, if auto-detection needs to be bypassed for a new app
+///   build. When nil, the address is located automatically.
+func extractDrawCategoryAutomatically(
+    appPath: String,
+    drawFilePath: URL,
+    drawFuncOverride: UInt64?,
+    workingDir: URL
+) -> Bool {
+    guard isCommandAvailable("lldb"), isCommandAvailable("codesign"), isCommandAvailable("otool") else {
+        print("⚠️  Draw auto-extraction needs lldb/codesign/otool (Xcode CLT). Falling back to manual capture.")
+        return false
+    }
+
+    // 1. Symbol scalars (name ↔ PUA) from the decrypted font table.
+    guard let puaToNames = loadSympPUAToNames(appPath: appPath) else {
+        print("⚠️  Could not read the font 'symp' table for Draw extraction. Falling back to manual capture.")
+        return false
+    }
+    let scalars: [UInt32] = puaToNames.keys.compactMap { UInt32($0, radix: 16) }.sorted()
+    guard !scalars.isEmpty else { return false }
+
+    guard let exeName = bundleExecutableName(appPath: appPath) else {
+        print("⚠️  Could not read the app's executable name. Falling back to manual capture.")
+        return false
+    }
+    let appExe = URL(fileURLWithPath: appPath).appendingPathComponent("Contents/MacOS/\(exeName)").path
+
+    // 2. Locate the draw-check closure (sole hasDrawInfo caller).
+    guard let drawFunc = drawFuncOverride ?? locateDrawCheckFunction(appExe: appExe) else {
+        print("⚠️  Could not locate the draw-check function in the app binary (it may have moved in this build). Pass --draw-func 0x… or fall back to manual capture.")
+        return false
+    }
+    print(String(format: "🔎 Draw-check function at 0x%llx", drawFunc))
+
+    // 3. Clone + re-sign a debuggable copy.
+    guard let copyExe = makeDebuggableCopy(appPath: appPath, exeName: exeName, workingDir: workingDir) else {
+        print("⚠️  Could not create a debuggable app copy. Falling back to manual capture.")
+        return false
+    }
+    defer { try? FileManager.default.removeItem(at: URL(fileURLWithPath: copyExe).deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()) }
+
+    // 4. Drive the app under lldb to evaluate every scalar, with a live progress bar.
+    let outURL = workingDir.appendingPathComponent("draw_out.tsv")
+    guard runLLDBExtraction(copyExe: copyExe, drawFunc: drawFunc, scalars: scalars, outURL: outURL, workingDir: workingDir) else {
+        print("⚠️  lldb Draw extraction did not complete. Falling back to manual capture.")
+        return false
+    }
+
+    // 5. Map draw-flagged scalars → names → draw.txt.
+    guard let results = try? String(contentsOf: outURL, encoding: .utf8) else { return false }
+    var drawNames = Set<String>()
+    for line in results.split(separator: "\n") {
+        let parts = line.split(separator: "\t")
+        guard parts.count == 2, parts[1] == "1" else { continue }
+        let hex = String(parts[0]).uppercased()
+        if let names = puaToNames[hex] { drawNames.formUnion(names) }
+    }
+    guard !drawNames.isEmpty else {
+        print("⚠️  Draw extraction produced no symbols. Falling back to manual capture.")
+        return false
+    }
+
+    do {
+        try drawNames.sorted().joined(separator: "\n").write(to: drawFilePath, atomically: true, encoding: .utf8)
+        print("☑️  Auto-extracted Draw category: \(drawNames.count) symbols → draw.txt")
+        return true
+    } catch {
+        print("⚠️  Could not write draw.txt: \(error). Falling back to manual capture.")
+        return false
+    }
+}
+
+// MARK: - Step 2: locate the draw-check closure
+
+/// The draw-check closure is the SOLE function that calls
+/// `UnifiedSymbolAnnotation.hasDrawInfo`. We find that `bl` in the app's
+/// disassembly, then walk backward to the enclosing function's prologue (the
+/// instruction right after the previous function's terminator).
+private func locateDrawCheckFunction(appExe: String) -> UInt64? {
+    guard let disasm = runProcess("/usr/bin/otool", ["-arch", "arm64", "-tV", appExe])?.stdout else { return nil }
+
+    // Parse "<hexaddr>\t<mnemonic> …" lines into (address, isTerminator, isCall-to-hasDrawInfo).
+    var addrs: [UInt64] = []
+    var isBoundary: [Bool] = []   // ret / brk → end of a function
+    var callIndex = -1
+    addrs.reserveCapacity(1 << 20); isBoundary.reserveCapacity(1 << 20)
+
+    disasm.enumerateLines { line, _ in
+        guard let tab = line.firstIndex(of: "\t") else { return }
+        let addrStr = line[line.startIndex..<tab]
+        guard let addr = UInt64(addrStr, radix: 16) else { return }
+        let rest = line[line.index(after: tab)...]
+        let i = addrs.count
+        addrs.append(addr)
+        isBoundary.append(rest.hasPrefix("ret") || rest.hasPrefix("brk"))
+        if callIndex < 0, rest.contains("hasDrawInfoSbvg"), rest.contains("bl") {
+            callIndex = i
+        }
+    }
+    guard callIndex >= 0 else { return nil }
+
+    // Walk back to the previous function boundary; the entry is the next instruction.
+    var j = callIndex - 1
+    while j > 0, !isBoundary[j] { j -= 1 }
+    let entryIndex = isBoundary[j] ? j + 1 : 0
+    return addrs[entryIndex]
+}
+
+// MARK: - Step 3: debuggable copy
+
+/// Clones the app (APFS copy-on-write, near-instant) into `workingDir` and re-signs
+/// the main executable ad-hoc with `get-task-allow` so lldb can drive it.
+/// Returns the path to the copied main executable.
+private func makeDebuggableCopy(appPath: String, exeName: String, workingDir: URL) -> String? {
+    let destApp = workingDir.appendingPathComponent("SFSymbolsDraw.app")
+    try? FileManager.default.removeItem(at: destApp)
+    guard runProcess("/bin/cp", ["-R", appPath, destApp.path])?.status == 0 else { return nil }
+
+    let ent = workingDir.appendingPathComponent("get-task-allow.plist")
+    let entXML = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0"><dict><key>com.apple.security.get-task-allow</key><true/></dict></plist>
+    """
+    guard (try? entXML.write(to: ent, atomically: true, encoding: .utf8)) != nil else { return nil }
+
+    let copyExe = destApp.appendingPathComponent("Contents/MacOS/\(exeName)").path
+    let sign = runProcess("/usr/bin/codesign", ["--force", "--sign", "-", "--entitlements", ent.path, copyExe])
+    guard sign?.status == 0 else { return nil }
+    return copyExe
+}
+
+// MARK: - Step 4: drive lldb with a progress bar
+
+private func runLLDBExtraction(copyExe: String, drawFunc: UInt64, scalars: [UInt32], outURL: URL, workingDir: URL) -> Bool {
+    let inURL = workingDir.appendingPathComponent("draw_in_scalars.txt")
+    let pyURL = workingDir.appendingPathComponent("extract_draw.py")
+    let driveURL = workingDir.appendingPathComponent("drive_extract.lldb")
+    try? scalars.map { String($0, radix: 16).uppercased() }.joined(separator: "\n").write(to: inURL, atomically: true, encoding: .utf8)
+    try? FileManager.default.removeItem(at: outURL)
+    guard (try? lldbExtractorPython.write(to: pyURL, atomically: true, encoding: .utf8)) != nil else { return false }
+
+    let drive = """
+    command script import \(shQuote(pyURL.path))
+    process launch --stop-at-entry
+    command script add -f extract_draw.setup draw_setup
+    draw_setup
+    continue
+    """
+    guard (try? drive.write(to: driveURL, atomically: true, encoding: .utf8)) != nil else { return false }
+
+    let proc = Process()
+    proc.executableURL = URL(fileURLWithPath: "/usr/bin/lldb")
+    proc.arguments = ["-b", "-s", driveURL.path, copyExe]
+    var env = ProcessInfo.processInfo.environment
+    env["DRAW_FUNC"] = String(format: "0x%llx", drawFunc)
+    env["DRAW_IN"] = inURL.path
+    env["DRAW_OUT"] = outURL.path
+    proc.environment = env
+    proc.standardOutput = FileHandle.nullDevice
+    proc.standardError = FileHandle.nullDevice
+
+    do { try proc.run() } catch { return false }
+
+    // Poll the incremental output for a live progress bar (the app appears frozen
+    // while lldb drives it — that's expected; the copy is killed when done).
+    let total = scalars.count
+    let deadline = Date().addingTimeInterval(600) // 10-minute safety timeout
+    print("⏳ Driving the app under lldb to evaluate \(total) symbols…")
+    while proc.isRunning {
+        if Date() > deadline { proc.terminate(); break }
+        let done = lineCount(of: outURL)
+        printProgress(done: done, total: total)
+        Thread.sleep(forTimeInterval: 0.4)
+    }
+    proc.waitUntilExit()
+    printProgress(done: lineCount(of: outURL), total: total)
+    print("")  // end the progress line
+
+    // Success if we evaluated (close to) every scalar.
+    return lineCount(of: outURL) >= total
+}
+
+/// The lldb Python harness. On the first natural breakpoint hit it captures the
+/// live symbol-store context, disables the breakpoint (stopping the render churn),
+/// then calls the draw-check function directly for every input scalar — fabricating
+/// each element from a real one (only the leading 4-byte scalar differs).
+private let lldbExtractorPython = """
+import lldb, os
+DRAW_FUNC = int(os.environ.get("DRAW_FUNC", "0"), 16)
+IN  = os.environ["DRAW_IN"]
+OUT = os.environ["DRAW_OUT"]
+_done = {"v": False}
+
+def on_hit(frame, bp_loc, d):
+    if _done["v"]:
+        return False
+    _done["v"] = True
+    process = frame.GetThread().GetProcess(); target = process.GetTarget()
+    err = lldb.SBError()
+    ctx  = frame.FindRegister("x1").GetValueAsUnsigned()
+    el0  = frame.FindRegister("x0").GetValueAsUnsigned()
+    tail = process.ReadMemory(el0 + 4, 16, err)
+    scratch = process.AllocateMemory(32, 3, err)
+    func = target.ResolveFileAddress(DRAW_FUNC).GetLoadAddress(target)
+    bp_loc.GetBreakpoint().SetEnabled(False)
+    opts = lldb.SBExpressionOptions(); opts.SetIgnoreBreakpoints(True); opts.SetTimeoutInMicroSeconds(3000000)
+    scalars = [int(x, 16) for x in open(IN) if x.strip()]
+    out = open(OUT, "w")
+    for s in scalars:
+        process.WriteMemory(scratch, s.to_bytes(4, "little") + tail, err)
+        expr = "(unsigned int)((unsigned char(*)(void*,void*))%d)((void*)%d,(void*)%d)" % (func, scratch, ctx)
+        v = frame.EvaluateExpression(expr, opts)
+        out.write("%X\\t%d\\n" % (s, v.GetValueAsUnsigned() & 1)); out.flush()
+    out.close()
+    process.Kill()   # let `lldb -b` exit
+    return False
+
+def setup(debugger, command, result, internal_dict):
+    t = debugger.GetSelectedTarget()
+    bp = t.BreakpointCreateBySBAddress(t.ResolveFileAddress(DRAW_FUNC))
+    bp.SetScriptCallbackFunction("extract_draw.on_hit")
+"""
+
+// MARK: - Small helpers
+
+private func bundleExecutableName(appPath: String) -> String? {
+    let info = URL(fileURLWithPath: appPath).appendingPathComponent("Contents/Info.plist")
+    guard let data = try? Data(contentsOf: info),
+          let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
+          let exe = plist["CFBundleExecutable"] as? String else { return nil }
+    return exe
+}
+
+private func isCommandAvailable(_ name: String) -> Bool {
+    runProcess("/usr/bin/which", [name])?.status == 0
+}
+
+private func runProcess(_ launchPath: String, _ args: [String]) -> (status: Int32, stdout: String)? {
+    let proc = Process()
+    proc.executableURL = URL(fileURLWithPath: launchPath)
+    proc.arguments = args
+    let pipe = Pipe()
+    proc.standardOutput = pipe
+    proc.standardError = FileHandle.nullDevice
+    do { try proc.run() } catch { return nil }
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    proc.waitUntilExit()
+    return (proc.terminationStatus, String(data: data, encoding: .utf8) ?? "")
+}
+
+private func lineCount(of url: URL) -> Int {
+    guard let s = try? String(contentsOf: url, encoding: .utf8), !s.isEmpty else { return 0 }
+    return s.reduce(0) { $1 == "\n" ? $0 + 1 : $0 }
+}
+
+private func printProgress(done: Int, total: Int) {
+    let width = 30
+    let frac = total > 0 ? min(1.0, Double(done) / Double(total)) : 0
+    let filled = Int(frac * Double(width))
+    let bar = String(repeating: "█", count: filled) + String(repeating: "░", count: width - filled)
+    let pct = Int(frac * 100)
+    print("\r   [\(bar)] \(pct)%  \(done)/\(total)", terminator: "")
+    fflush(stdout)
+}
+
+private func shQuote(_ s: String) -> String { "\"\(s.replacingOccurrences(of: "\"", with: "\\\""))\"" }

--- a/Tools/Sources/SFSymbolsGenKit/README.md
+++ b/Tools/Sources/SFSymbolsGenKit/README.md
@@ -30,8 +30,7 @@ The `sfsym-gen` executable is a thin ArgumentParser wrapper over these.
 ## The `update` pipeline (`runUpdate`)
 
 ```
-draw.txt  ─┐
-            ├─► [1] Draw category   (UpdatePipeline.swift)  reads/prompts <repoRoot>/draw.txt
+            ┌─► [1] Draw category   (DrawExtraction.swift)  drive app's hasDrawInfo under lldb → draw.txt
 SF Symbols ─┤
    app      ├─► [2] Decrypt          (Decrypt.swift)        font `symp` table → font_restrictions.tsv
             │
@@ -39,6 +38,12 @@ CoreGlyphs ─┼─► [3] Generate         (GenerateSymbolsJSON)  merge → sy
    bundle   │
             └─► [4] Write sources     (UpdatePipeline.swift) symbols.json → Sources/SFSymbols/**
 ```
+
+Step 1 auto-extracts the Draw category by driving the app's own `hasDrawInfo` logic
+(clone + ad-hoc re-sign the app, then call its draw-check function for every glyph
+under lldb — see `DrawExtraction.swift`). It soft-fails
+to a manual clipboard prompt. Use `sfsym-gen draw` to run just this step, or
+`--draw-func 0x…` to override the auto-detected function address after an app update.
 
 Steps 1–3 communicate through small files in a temp working directory (`draw.txt`,
 `font_restrictions.tsv`, `symbols.json`) — the same boundaries the original scripts
@@ -58,7 +63,7 @@ used, which is why the output is byte-for-byte identical to the old pipeline.
 | System CoreGlyphs bundle (`/System/Library/CoreServices/CoreGlyphs.bundle`) | **primary** | names, availability, deprecation aliases, category mappings, restrictions |
 | SF Symbols app `Metadata/` | **union/supplement** | symbols for an unreleased OS not yet in CoreGlyphs, layersets, category labels, search terms |
 | SF Symbols font `symp` table (decrypted) | **authoritative restrictions** | use-restriction text for every symbol, incl. unreleased-OS symbols CoreGlyphs lacks |
-| Manual clipboard capture | **Draw category** | the Draw category membership (not present in any metadata file) |
+| App's own `hasDrawInfo` (driven under lldb) | **Draw category** | the Draw category membership (computed at render time; not present in any metadata file) |
 
 Because CoreGlyphs is tied to the installed OS, run the pipeline on the **latest
 macOS** so deprecation/restriction data is current. The app-metadata union is what
@@ -108,8 +113,9 @@ swift run --package-path Tools sfsym-gen wrappers swiftui --rtf SwiftUIDocumenat
 swift run --package-path Tools sfsym-gen wrappers uikit   --rtf UIKitDocumentationFromXcode.rtf
 ```
 
-See the repo `README.md` ("Updating The Symbols") for the end-to-end maintainer flow,
-including the manual Draw-category capture.
+See the repo `README.md` ("Updating The Symbols") for the end-to-end maintainer flow.
+The Draw category is now extracted automatically (see `DrawExtraction.swift` and the
+`update-sf-symbols` skill).
 
 ---
 

--- a/Tools/Sources/SFSymbolsGenKit/UpdatePipeline.swift
+++ b/Tools/Sources/SFSymbolsGenKit/UpdatePipeline.swift
@@ -585,7 +585,7 @@ private func versionString(_ version: Double) -> String {
 /// File-based intermediate boundaries are preserved via a temp working directory:
 /// the decrypt step writes `font_restrictions.tsv` there, the generate step writes
 /// `symbols.json` there and reads `draw.txt` + `font_restrictions.tsv` from there.
-public func runUpdate(appPath: String, repoRoot: URL) throws {
+public func runUpdate(appPath: String, repoRoot: URL, drawFunc: UInt64? = nil) throws {
     let metadataSubpath = "Contents/Resources/Metadata"
     let inputURL = URL(fileURLWithPath: appPath)
         .appendingPathComponent(metadataSubpath, isDirectory: true)
@@ -606,8 +606,22 @@ public func runUpdate(appPath: String, repoRoot: URL) throws {
     let repoDrawFilePath = repoRoot.appendingPathComponent("draw.txt")
     let symbolsJSONPath = workingDir.appendingPathComponent("symbols.json")
 
-    // Step 1: Ensure draw.txt exists (prompt user if needed)
-    ensureDrawCategoryExists(drawFilePath: repoDrawFilePath)
+    // Step 1: Draw category. Draw membership lives in no metadata file — it is
+    // computed by the app from glyph geometry. We auto-extract it by driving the
+    // app's own `hasDrawInfo` logic under lldb; if that fails, fall back to the
+    // manual clipboard capture.
+    if FileManager.default.fileExists(atPath: repoDrawFilePath.path) {
+        print("📋 Found existing draw.txt")
+    } else if extractDrawCategoryAutomatically(
+        appPath: appPath,
+        drawFilePath: repoDrawFilePath,
+        drawFuncOverride: drawFunc,
+        workingDir: workingDir
+    ) {
+        // draw.txt written automatically.
+    } else {
+        ensureDrawCategoryExists(drawFilePath: repoDrawFilePath)
+    }
 
     // Make the repo-root draw.txt available to the generate step in the working dir.
     if FileManager.default.fileExists(atPath: repoDrawFilePath.path) {

--- a/Tools/Sources/sfsym-gen/SFSymGen.swift
+++ b/Tools/Sources/sfsym-gen/SFSymGen.swift
@@ -12,7 +12,7 @@ struct SFSymGen: ParsableCommand {
         run it from the repository root (or pass --repo-root).
         """,
         version: "0.1.0",
-        subcommands: [Update.self, Wrappers.self]
+        subcommands: [Update.self, Wrappers.self, Draw.self]
     )
 }
 
@@ -35,6 +35,12 @@ extension SFSymGen {
         @Option(help: "Path to the SF Symbols app (defaults to the first installed one).")
         var app: String?
 
+        @Option(
+            name: .customLong("draw-func"),
+            help: "Override the auto-detected draw-check function address (e.g. 0x1000ec6bc) if Draw auto-extraction can't locate it in a new app build."
+        )
+        var drawFunc: String?
+
         func run() throws {
             let appPath: String
             if let app {
@@ -44,7 +50,58 @@ extension SFSymGen {
             } else {
                 throw ValidationError("No SF Symbols app found in \(SymbolsApp.candidates.joined(separator: " or ")). Pass --app.")
             }
-            try runUpdate(appPath: appPath, repoRoot: repo.url)
+
+            var drawFuncAddr: UInt64?
+            if let drawFunc {
+                let hex = drawFunc.hasPrefix("0x") ? String(drawFunc.dropFirst(2)) : drawFunc
+                guard let value = UInt64(hex, radix: 16) else {
+                    throw ValidationError("--draw-func must be a hex address, e.g. 0x1000ec6bc")
+                }
+                drawFuncAddr = value
+            }
+
+            try runUpdate(appPath: appPath, repoRoot: repo.url, drawFunc: drawFuncAddr)
+        }
+    }
+
+    struct Draw: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "draw",
+            abstract: "Extract only the Draw category by driving the app's own hasDrawInfo logic, writing the symbol names to a file."
+        )
+
+        @Option(help: "Path to the SF Symbols app (defaults to the first installed one).")
+        var app: String?
+
+        @Option(name: .customLong("draw-func"), help: "Override the auto-detected draw-check function address (e.g. 0x1000ec6bc).")
+        var drawFunc: String?
+
+        @Option(help: "Output path for the extracted draw symbol names.")
+        var output: String = "draw.txt"
+
+        func run() throws {
+            let appPath: String
+            if let app {
+                appPath = app
+            } else if let located = SymbolsApp.locate() {
+                appPath = located
+            } else {
+                throw ValidationError("No SF Symbols app found in \(SymbolsApp.candidates.joined(separator: " or ")). Pass --app.")
+            }
+
+            var drawFuncAddr: UInt64?
+            if let drawFunc {
+                let hex = drawFunc.hasPrefix("0x") ? String(drawFunc.dropFirst(2)) : drawFunc
+                guard let value = UInt64(hex, radix: 16) else {
+                    throw ValidationError("--draw-func must be a hex address, e.g. 0x1000ec6bc")
+                }
+                drawFuncAddr = value
+            }
+
+            let outputURL = URL(fileURLWithPath: output)
+            guard extractDrawCategory(appPath: appPath, outputPath: outputURL, drawFunc: drawFuncAddr) else {
+                throw ValidationError("Draw extraction failed. See the messages above.")
+            }
         }
     }
 


### PR DESCRIPTION
Replaces the manual "open the app, select Draw, ⌘A, ⌘C" clipboard step with a **turnkey** extractor for the Draw category — the one piece of metadata that lives in no readable file (the app computes it at render time from glyph geometry).

### How it works (`DrawExtraction.swift`)
1. Decrypt the font `symp` table → name↔PUA map (`Decrypt.swift`).
2. Auto-locate the draw-check closure (the sole `hasDrawInfo` caller) by disassembling the app binary.
3. Clone the app (APFS copy-on-write) and ad-hoc re-sign it with `get-task-allow` so it's debuggable.
4. Drive the copy under lldb: capture the live symbol-store context on first render, then call the draw-check function for every glyph scalar. Map draw-flagged scalars → names → `draw.txt`. Live progress bar; the throwaway copy is killed when done.

Soft-fails to the old manual clipboard prompt if anything breaks.

### Surface
- `sfsym-gen update` runs it automatically as step 1.
- `sfsym-gen draw` runs just this step (debug/standalone).
- `--draw-func 0x…` overrides auto-detection after an app build moves the function.
- `update-sf-symbols` skill + `SFSymbolsGenKit/README.md` updated with usage and the address re-derivation recipe.

### Verified
Against SF Symbols 8.0 (123): **2031 draw symbols**, internally consistent and a strict superset of the previously hand-captured 773.

This PR is **tooling only**. The regenerated sources that apply the 2031 tags are stacked on top in #36 (base `feature/draw-support`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)