### PR TITLE
docs: clarify the latest-macOS requirement (and what no longer needs it)

### DIFF
--- a/.claude/skills/update-sf-symbols/SKILL.md
+++ b/.claude/skills/update-sf-symbols/SKILL.md
@@ -11,8 +11,10 @@ commands from the repository root.
 
 ## 0. Prerequisites
 - Install the target **SF Symbols Beta app** at `/Applications/SF Symbols Beta.app`.
-- Run on the **latest macOS** — deprecation/restriction data comes from the system
-  CoreGlyphs bundle, which is tied to the OS version.
+- Run on the **latest macOS** — only the system CoreGlyphs bundle is OS-tied (it
+  supplies deprecation aliases, availability, and category mappings). Restrictions,
+  Unicode points, and the Draw category come from the app itself (OS-independent), so
+  this is purely about keeping CoreGlyphs' deprecation/availability data current.
 - **Xcode command-line tools** (`lldb`, `codesign`, `otool`) — required for automatic
   Draw-category extraction (step 1). Verify with `xcode-select -p`.
 - Confirm the version you're targeting: `defaults read "/Applications/SF Symbols Beta.app/Contents/Info.plist" CFBundleShortVersionString` (and `CFBundleVersion`).

--- a/README.md
+++ b/README.md
@@ -97,28 +97,34 @@ Thats what this micro library aims to do. Additionally, this library includes re
 
 ## Data Sources
 
-The library generates symbol data from two sources:
+The library generates symbol data from the system CoreGlyphs bundle and the SF Symbols
+app (its metadata **and** its font):
 
-### System CoreGlyphs Bundle (Primary)
+### System CoreGlyphs Bundle (Primary — OS-tied)
 The system's CoreGlyphs bundle is the **primary** data source, providing:
 - Symbol names and availability
 - Deprecation aliases (renamed symbols)
 - Category mappings
-- Usage restrictions
 
 ```
 /System/Library/CoreServices/CoreGlyphs.bundle/Contents/Resources/
 ```
 
-**Why CoreGlyphs?** This bundle is always current with your OS version and contains the same data that `UIImage(systemName:)` uses at runtime. Using CoreGlyphs ensures:
-- Symbol names match what the OS actually supports
-- Deprecation warnings point to symbols that exist
-- Generated code stays in sync with runtime behavior
+**Why CoreGlyphs?** It's always current with your OS version and contains the same data
+`UIImage(systemName:)` uses at runtime, so names match what the OS supports and
+deprecation warnings point to symbols that exist. Because it's **tied to the installed
+OS**, run the update on the latest macOS for current deprecation/availability data — see
+[Updating The Symbols](#updating-the-symbols).
 
-### SF Symbols App Metadata (Supplementary)
-The SF Symbols app provides supplementary data not available in CoreGlyphs:
-- Layerset availability (hierarchical, multicolor rendering support)
-- Category definitions (human-readable labels)
+### SF Symbols App (Supplementary — OS-independent)
+The app ships its own metadata and font, read directly from the app bundle. Because this
+travels with the app, it stays correct **even on an older macOS**:
+- **App `Metadata/`** — symbols for an unreleased OS not yet in CoreGlyphs, layerset
+  availability (hierarchical/multicolor), category labels, search terms.
+- **App font (`symp` table, decrypted)** — authoritative **use-restrictions** and
+  **Unicode code points**, including for new-OS symbols CoreGlyphs doesn't yet know.
+- **Draw category** — computed by driving the app's own `hasDrawInfo` logic under lldb;
+  it isn't stored in any metadata file (see [Updating The Symbols](#updating-the-symbols)).
 
 ```
 /Applications/SF Symbols.app/Contents/Resources/Metadata/
@@ -153,7 +159,7 @@ If you have any suggestions or ideas for improving the project, please feel free
 
 To update the SFSymbols files, follow these steps. The `sfsym-gen update` command will automatically handle updating all relevant files in place.
 
-> **Important:** Run the update script on the latest macOS version. The deprecation data comes from the system's CoreGlyphs bundle, which is updated with each OS release. Using an older macOS may result in missing or outdated deprecation warnings.
+> **Important:** Run the update on the latest macOS. The system **CoreGlyphs bundle** is tied to your OS and supplies deprecation aliases, base availability, and category mappings, so an older macOS may yield missing or outdated deprecation data. This is now the *only* reason to be current — use-restrictions and Unicode code points come authoritatively from the app's font, and the Draw category is computed from the app itself, all OS-independent.
 
 1. **Navigate to the `SFSymbols` directory** in your terminal:
 
@@ -161,15 +167,14 @@ To update the SFSymbols files, follow these steps. The `sfsym-gen update` comman
     cd path/to/SFSymbols
     ```
 
-2. **Prepare the Draw category** (first time only):
+2. **Draw category (automatic):**
 
-   The "Draw" category is not included in Apple's `symbol_categories.plist`, so it must be captured manually:
-   - Open the SF Symbols app
-   - Select "Draw" from the sidebar
-   - Select all symbols (Cmd+A)
-   - Copy symbol names (Cmd+Shift+C)
-
-   When you run the update command, it will prompt you to press Enter to read from your clipboard.
+   The "Draw" category isn't in any metadata file — the app computes it at render time
+   from glyph geometry. The update extracts it automatically by driving the app's own
+   `hasDrawInfo` logic under lldb (it clones and ad-hoc re-signs the app, so **Xcode
+   command-line tools** must be installed). No manual step is required; it falls back to
+   a clipboard prompt only if extraction fails. See the `update-sf-symbols` skill for
+   details and the `--draw-func` override.
 
 3. **Run the update command** with the path to your SF Symbols application:
 
@@ -179,7 +184,7 @@ To update the SFSymbols files, follow these steps. The `sfsym-gen update` comman
 
 4. **Update the `CHANGELOG.md`** with any relevant notes about the new symbols or changes.
 
-> **Note:** The Draw category symbols are saved to `draw.txt` during the update and cleaned up automatically afterward. If you need to update the Draw category in subsequent runs, delete any existing `draw.txt` file first.
+> **Note:** The Draw category is written to a temporary `draw.txt` during the update and cleaned up automatically afterward. Pre-stage your own `draw.txt` in the repo root to skip auto-extraction.
 
 > **Use-restrictions:** The update command automatically decrypts the SF Symbols app's font `symp` metadata table in-process, reusing the app's own routine to extract authoritative use-restriction text (written to a temporary `font_restrictions.tsv`). This covers symbols for an unreleased OS that the system CoreGlyphs bundle doesn't yet know about. It resolves a private framework symbol at runtime (via `dlopen` of the app's CoreGlyphsLib) and is used only for local code generation — never shipped. If it ever fails (e.g. Apple renames the symbol), the command logs a warning and falls back to CoreGlyphs restrictions.
 

--- a/Tools/Sources/SFSymbolsGenKit/README.md
+++ b/Tools/Sources/SFSymbolsGenKit/README.md
@@ -60,14 +60,16 @@ used, which is why the output is byte-for-byte identical to the old pipeline.
 
 | Source | Role | Provides |
 |---|---|---|
-| System CoreGlyphs bundle (`/System/Library/CoreServices/CoreGlyphs.bundle`) | **primary** | names, availability, deprecation aliases, category mappings, restrictions |
-| SF Symbols app `Metadata/` | **union/supplement** | symbols for an unreleased OS not yet in CoreGlyphs, layersets, category labels, search terms |
-| SF Symbols font `symp` table (decrypted) | **authoritative restrictions** | use-restriction text for every symbol, incl. unreleased-OS symbols CoreGlyphs lacks |
-| App's own `hasDrawInfo` (driven under lldb) | **Draw category** | the Draw category membership (computed at render time; not present in any metadata file) |
+| System CoreGlyphs bundle (`/System/Library/CoreServices/CoreGlyphs.bundle`) | **primary, OS-tied** | names, availability, deprecation aliases, category mappings |
+| SF Symbols app `Metadata/` | **union/supplement, OS-independent** | symbols for an unreleased OS not yet in CoreGlyphs, layersets, category labels, search terms |
+| SF Symbols font `symp` table (decrypted) | **authoritative, OS-independent** | use-restriction text + Unicode code points for every symbol, incl. unreleased-OS symbols CoreGlyphs lacks |
+| App's own `hasDrawInfo` (driven under lldb) | **Draw category, OS-independent** | the Draw category membership (computed at render time; not present in any metadata file) |
 
-Because CoreGlyphs is tied to the installed OS, run the pipeline on the **latest
-macOS** so deprecation/restriction data is current. The app-metadata union is what
-lets a beta app contribute symbols for an OS the host doesn't run yet.
+Only the **CoreGlyphs** row is tied to the installed OS, so run the pipeline on the
+**latest macOS** to keep its deprecation/availability/category data current. The other
+three sources travel with the app, so restrictions, unicodes, and Draw are correct on
+any macOS — and the app-metadata union is what lets a beta app contribute symbols for an
+OS the host doesn't run yet.
 
 ---
 


### PR DESCRIPTION
Corrects the docs around the "run on the latest macOS" requirement now that more data comes from the app rather than the OS.

### The accurate picture
- **OS-tied (needs latest macOS):** the system **CoreGlyphs** bundle — deprecation aliases, base availability, category mappings.
- **OS-independent (no longer needs it):**
  - **Use-restrictions + Unicode code points** — authoritative from the app's decrypted font `symp` table.
  - **Draw category** — computed by driving the app's own `hasDrawInfo` under lldb.

So the latest-macOS requirement still stands, but **only** for CoreGlyphs' deprecation/availability/category currency.

### Also fixes stale docs
- CoreGlyphs was still listed as a *restrictions* source (it isn't anymore).
- The "Updating The Symbols" steps still described the **manual** Draw clipboard capture — replaced with the automatic extraction (+ the Xcode CLT prerequisite).

Touches the root `README.md`, `Tools/Sources/SFSymbolsGenKit/README.md`, and the `update-sf-symbols` skill. Docs only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)